### PR TITLE
Fix container builder registration

### DIFF
--- a/engine/builders/containerBuilder.ts
+++ b/engine/builders/containerBuilder.ts
@@ -1,5 +1,7 @@
 import { GameEngine, gameEngineDependencies, gameEngineToken, IGameEngine } from '@engine/gameEngine'
 import { Container } from '@ioc/container'
+import { MessageBus, messageBusDependencies, messageBusToken } from '@utils/messageBus'
+import { MessageQueue, messageQueueToken } from '@utils/messageQueue'
 
 export interface IContainerBuilder {
     build(): Container
@@ -7,10 +9,19 @@ export interface IContainerBuilder {
 
 export class ContainerBuilder implements IContainerBuilder {
     public build(): Container {
-        const result =  new Container()
+        const result = new Container()
+        result.register({
+            token: messageQueueToken,
+            useFactory: () => new MessageQueue(() => {})
+        })
+        result.register({
+            token: messageBusToken,
+            useFactory: c => new MessageBus(c.resolve(messageQueueToken)),
+            deps: messageBusDependencies
+        })
         result.register<IGameEngine>({
             token: gameEngineToken,
-            useClass: GameEngine,
+            useFactory: c => new GameEngine(c.resolve(messageBusToken)),
             deps: gameEngineDependencies
         })
         return result

--- a/tests/engine/containerBuilder.test.ts
+++ b/tests/engine/containerBuilder.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest'
+import { ContainerBuilder } from '@builders/containerBuilder'
+import { gameEngineToken } from '@engine/gameEngine'
+import { messageBusToken } from '@utils/messageBus'
+import { messageQueueToken } from '@utils/messageQueue'
+import { GameEngine } from '@engine/gameEngine'
+import { MessageBus } from '@utils/messageBus'
+import { MessageQueue } from '@utils/messageQueue'
+
+describe('ContainerBuilder', () => {
+  it('registers default dependencies', () => {
+    const builder = new ContainerBuilder()
+    const container = builder.build()
+    const engine = container.resolve(gameEngineToken)
+    const bus = container.resolve(messageBusToken)
+    const queue = container.resolve(messageQueueToken)
+    expect(engine).toBeInstanceOf(GameEngine)
+    expect(bus).toBeInstanceOf(MessageBus)
+    expect(queue).toBeInstanceOf(MessageQueue)
+  })
+})


### PR DESCRIPTION
## Summary
- Register MessageQueue and MessageBus dependencies in ContainerBuilder
- Build game engine via factory to resolve required MessageBus dependency
- Add tests verifying ContainerBuilder wires default providers

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68990385442c833297e56d43e83925e3