### PR TITLE
Use class providers for engine dependencies

### DIFF
--- a/engine/builders/containerBuilder.ts
+++ b/engine/builders/containerBuilder.ts
@@ -16,12 +16,12 @@ export class ContainerBuilder implements IContainerBuilder {
         })
         result.register({
             token: messageBusToken,
-            useFactory: c => new MessageBus(c.resolve(messageQueueToken)),
+            useClass: MessageBus,
             deps: messageBusDependencies
         })
         result.register<IGameEngine>({
             token: gameEngineToken,
-            useFactory: c => new GameEngine(c.resolve(messageBusToken)),
+            useClass: GameEngine,
             deps: gameEngineDependencies
         })
         return result

--- a/engine/ioc/types.ts
+++ b/engine/ioc/types.ts
@@ -1,6 +1,9 @@
 import type { Token } from './token'
 
-export type Class<T> = new (...args: unknown[]) => T
+// Allow classes with any constructor parameters to be used by the IoC container.
+// Using `any[]` here lets us register classes whose constructors expect
+// specific dependency types without TypeScript rejecting them.
+export type Class<T> = new (...args: any[]) => T // eslint-disable-line @typescript-eslint/no-explicit-any
 export type Factory<T> = (c: Container) => T
 
 export type Scope = 'singleton' | 'transient'


### PR DESCRIPTION
## Summary
- Allow IoC `Class` types to accept any constructor parameters
- Register `MessageBus` and `GameEngine` using `useClass` with their dependency tokens

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_689907966e388332b1356c209df770a4