### PR TITLE
Wrap engine startup in async IIFE

### DIFF
--- a/engine/main.tsx
+++ b/engine/main.tsx
@@ -19,5 +19,11 @@ if (rootElement) {
   )
 }
 
-const engine = container.resolve<IGameEngine>(gameEngineToken)
-await engine.start()
+(async () => {
+  try {
+    const engine = container.resolve<IGameEngine>(gameEngineToken)
+    await engine.start()
+  } catch (err) {
+    console.error('Engine failed to start', err)
+  }
+})()


### PR DESCRIPTION
## Summary
- Replace top-level `await` with an async IIFE that starts the engine and logs initialization errors

## Testing
- `npm run lint`
- `npm run build`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6899e54eaee883328acb9cd405eebb45