### PR TITLE
test: add message bus and queue tests

### DIFF
--- a/tests/engine/messageBus.test.ts
+++ b/tests/engine/messageBus.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from 'vitest'
+import { MessageBus } from '@utils/messageBus'
+import { MessageQueue } from '@utils/messageQueue'
+import type { Message } from '@utils/types'
+
+describe('MessageBus', () => {
+  it('delivers posted messages to registered listeners', async () => {
+    const queue = new MessageQueue(() => {})
+    const bus = new MessageBus(queue)
+    const handler = vi.fn()
+    bus.registerMessageListener('test', handler)
+
+    const msg: Message = { message: 'test', payload: 123 }
+    bus.postMessage(msg)
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(handler).toHaveBeenCalledWith(msg)
+  })
+
+  it('unregistering listener prevents it from receiving messages', async () => {
+    const queue = new MessageQueue(() => {})
+    const bus = new MessageBus(queue)
+    const handler = vi.fn()
+    const cleanup = bus.registerMessageListener('remove', handler)
+    cleanup()
+
+    bus.postMessage({ message: 'remove', payload: null })
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  it('queues messages when auto-drain is disabled and processes them when enabled', async () => {
+    const queue = new MessageQueue(() => {})
+    const bus = new MessageBus(queue)
+    const handled: Message[] = []
+    bus.registerMessageListener('queued', m => {
+      handled.push(m)
+    })
+
+    bus.disableEmptyQueueAfterPost()
+    bus.postMessage({ message: 'queued', payload: 1 })
+    bus.postMessage({ message: 'queued', payload: 2 })
+    expect(handled.length).toBe(0)
+
+    bus.enableEmptyQueueAfterPost()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(handled.map(m => m.payload)).toEqual([1, 2])
+  })
+})
+

--- a/tests/engine/messageQueue.test.ts
+++ b/tests/engine/messageQueue.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from 'vitest'
+import { MessageQueue } from '@utils/messageQueue'
+import type { Message } from '@utils/types'
+
+describe('MessageQueue', () => {
+  it('processes messages and calls handler', async () => {
+    const onEmpty = vi.fn()
+    const queue = new MessageQueue(onEmpty)
+    const handled: Message[] = []
+    queue.setHandler(m => {
+      handled.push(m)
+    })
+
+    queue.postMessage({ message: 'a', payload: null })
+    queue.postMessage({ message: 'b', payload: 1 })
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(handled.map(m => m.message)).toEqual(['a', 'b'])
+    expect(onEmpty).toHaveBeenCalledTimes(2)
+  })
+
+  it('queues messages when auto-drain disabled and drains when enabled', async () => {
+    const onEmpty = vi.fn()
+    const queue = new MessageQueue(onEmpty)
+    const handled: string[] = []
+    queue.setHandler(m => {
+      handled.push(m.message)
+    })
+
+    queue.disableEmptyQueueAfterPost()
+    queue.postMessage({ message: 'a', payload: null })
+    queue.postMessage({ message: 'b', payload: null })
+    expect(handled).toEqual([])
+
+    queue.enableEmptyQueueAfterPost()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(handled).toEqual(['a', 'b'])
+    expect(onEmpty).toHaveBeenCalledTimes(1)
+  })
+
+  it('drains queue manually and waits for async handlers', async () => {
+    const onEmpty = vi.fn()
+    const queue = new MessageQueue(onEmpty)
+    const order: string[] = []
+    queue.setHandler(async m => {
+      order.push(m.message)
+      await new Promise(res => setTimeout(res, 1))
+    })
+
+    queue.disableEmptyQueueAfterPost()
+    queue.postMessage({ message: 'a', payload: null })
+    queue.postMessage({ message: 'b', payload: null })
+    await queue.emptyQueue()
+
+    expect(order).toEqual(['a', 'b'])
+    expect(onEmpty).toHaveBeenCalledTimes(1)
+  })
+})
+


### PR DESCRIPTION
## Summary
- add tests for MessageBus covering dispatch, unregistration, and queued processing
- add tests for MessageQueue covering posting, auto-draining, and manual draining

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6899e5c3a22c83328d02af3a168f35d5