### PR TITLE
Lazily resolve TurnScheduler in queue callback

### DIFF
--- a/engine/main.tsx
+++ b/engine/main.tsx
@@ -11,9 +11,9 @@ import './styling/variables.css'
 import './styling/engine.css'
 
 const containerBuilder: IContainerBuilder = new ContainerBuilder(
-  container => {
+  container => () => {
     const scheduler = container.resolve(turnSchedulerToken)
-    return scheduler.onQueueEmpty.bind(scheduler)
+    scheduler.onQueueEmpty()
   },
 )
 const container: Container = containerBuilder.build()

--- a/tests/engine/containerBuilder.test.ts
+++ b/tests/engine/containerBuilder.test.ts
@@ -32,4 +32,16 @@ describe('ContainerBuilder', () => {
     await queue.emptyQueue()
     expect(callback).toHaveBeenCalledTimes(1)
   })
+
+  it('resolves gameEngine without circular dependency', () => {
+    const builder = new ContainerBuilder(
+      container => () => {
+        const scheduler = container.resolve(turnSchedulerToken)
+        scheduler.onQueueEmpty()
+      },
+    )
+    const container = builder.build()
+    const engine = container.resolve(gameEngineToken)
+    expect(engine).toBeInstanceOf(GameEngine)
+  })
 })

--- a/tests/engine/mappers.test.ts
+++ b/tests/engine/mappers.test.ts
@@ -24,7 +24,7 @@ describe('Loader mappers', () => {
       'virtual-inputs': ['vi1']
     }
 
-    const game = mapGame(input)
+    const game = mapGame(input, '')
     expect(game.title).toBe('My game')
     expect(game.initialData).toEqual({ language: 'en', startPage: 'start' })
   })


### PR DESCRIPTION
## Summary
- Resolve `TurnScheduler` inside the `onQueueEmpty` callback to avoid circular IoC loops
- Keep `ContainerBuilder` passing the provided callback straight through to `MessageQueue`
- Add regression test ensuring `gameEngineToken` resolves without circular dependency
- Align mapper test with updated `mapGame` signature

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_689a314dadb48332b75471f19fc64b4c