### PR TITLE
fix: correct translation key parameter

### DIFF
--- a/engine/services/translationService.ts
+++ b/engine/services/translationService.ts
@@ -5,7 +5,7 @@ import { fatalError } from '@utils/logMessage'
 const logName = 'TranslationService'
 
 export interface ITranslationService {
-    translate(ket: string): string
+    translate(key: string): string
     setLanguage(language: Language): void
 }
 


### PR DESCRIPTION
## Summary
- fix ITranslationService.translate parameter name to `key`

## Testing
- `npm run lint`
- `npm run build`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_689a51d6cf1c8332b7be2c510abb110d