### PR TITLE
Expose queue controls on message bus interface

### DIFF
--- a/utils/messageBus.ts
+++ b/utils/messageBus.ts
@@ -15,6 +15,8 @@ export interface IMessageBus {
     postMessage(message: Message<unknown>): void
     registerMessageListener(message: string, handler: (message: Message<unknown>) => void | Promise<void>): CleanUp
     registerNotificationMessage(message: string): void
+    disableEmptyQueueAfterPost(): void
+    enableEmptyQueueAfterPost(): void
     shutDown(): void
 }
 


### PR DESCRIPTION
## Summary
- Add `disableEmptyQueueAfterPost` and `enableEmptyQueueAfterPost` to `IMessageBus`

## Testing
- `npm run lint`
- `npm run build`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_689a533339d48332870f0032f93fd85a