### PR TITLE
Document third-party licenses and reference in build

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,4 @@ npm run build    # production build
 
 ## License
 This project is licensed under the [MPL-2.0](LICENSE).
+Third-party licenses are listed in [THIRD_PARTY_LICENSES.md](THIRD_PARTY_LICENSES.md).

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,24 @@
+# Third-Party Licenses
+
+This project uses the following third-party packages:
+
+| Package | Version | License |
+| --- | --- | --- |
+| @types/node | 24.2.1 | MIT |
+| @types/react | 18.3.23 | MIT |
+| @types/react-dom | 18.3.7 | MIT |
+| @typescript-eslint/eslint-plugin | 8.39.0 | MIT |
+| @typescript-eslint/parser | 8.39.0 | MIT |
+| @vitejs/plugin-react | 4.7.0 | MIT |
+| concurrently | 9.2.0 | MIT |
+| cross-env | 10.0.0 | MIT |
+| eslint | 9.33.0 | MIT |
+| globals | 16.3.0 | MIT |
+| jsdom | 26.1.0 | MIT |
+| react | 18.3.1 | MIT |
+| react-dom | 18.3.1 | MIT |
+| typescript | 5.9.2 | Apache-2.0 |
+| vite | 7.1.1 | MIT |
+| vite-plugin-static-copy | 3.1.1 | MIT |
+| vitest | 3.2.4 | MIT |
+| zod | 4.0.17 | MIT |

--- a/editor/editor.html
+++ b/editor/editor.html
@@ -8,6 +8,12 @@
   </head>
   <body>
     <div id="root"></div>
+    <footer>
+      <p>
+        Licensed under <a href="../LICENSE">MPL-2.0</a>. See
+        <a href="../THIRD_PARTY_LICENSES.md">third-party licenses</a>.
+      </p>
+    </footer>
     <script type="module" src="/editor/main.tsx"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -8,6 +8,12 @@
   </head>
   <body>
     <div id="root"></div>
+    <footer>
+      <p>
+        Licensed under <a href="LICENSE">MPL-2.0</a>. See
+        <a href="THIRD_PARTY_LICENSES.md">third-party licenses</a>.
+      </p>
+    </footer>
     <script type="module" src="/engine/main.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- list direct dependencies and their licenses in a new THIRD_PARTY_LICENSES.md
- reference MPL-2.0 and third-party licenses from engine and editor HTML
- mention new license file in README

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_689a59ebbe10833287ebf3f8abe7e709