### PR TITLE
Handle unknown language keys

### DIFF
--- a/engine/managers/languageManager.ts
+++ b/engine/managers/languageManager.ts
@@ -26,11 +26,14 @@ export class LanguageManager implements ILanguageManager {
     }
 
     public async setLanguage(languageKey: string): Promise<void> {
+        const paths = this.gameDataProvider.Game.game.languages[languageKey]
+        if (!paths) fatalError(logName, `Unknown language key: ${languageKey}`)
+
         if (this.gameDataProvider.Game.languages[languageKey] === undefined) {
-            const paths = this.gameDataProvider.Game.game.languages[languageKey]
             const language = await this.languageLoader.loadLanguage(paths)
             this.gameDataProvider.Game.languages[languageKey] = language
         }
+
         const languageData = this.gameDataProvider.Game.languages[languageKey]
         this.translationService.setLanguage(languageData)
         this.gameDataProvider.Context.language = languageKey

--- a/tests/engine/languageManager.test.ts
+++ b/tests/engine/languageManager.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from 'vitest'
+import { LanguageManager } from '../../engine/managers/languageManager'
+import type { ILanguageLoader } from '../../engine/loader/languageLoader'
+import type { ITranslationService } from '../../engine/services/translationService'
+import type { IGameDataProvider, GameData, GameContext } from '../../engine/providers/gameDataProvider'
+import type { Language } from '@loader/data/language'
+import type { Game } from '@loader/data/game'
+
+describe('LanguageManager', () => {
+  it('throws when unknown language key is requested', async () => {
+    const loader: ILanguageLoader = { loadLanguage: vi.fn() }
+    const translationService: ITranslationService = {
+      translate: vi.fn(),
+      setLanguage: vi.fn()
+    }
+    const gameData = {
+      game: { languages: {} } as unknown as Game,
+      languages: {} as Record<string, Language>
+    } as unknown as GameData
+    const context = {} as unknown as GameContext
+    const gameDataProvider: IGameDataProvider = {
+      get Game() {
+        return gameData
+      },
+      get Context() {
+        return context
+      },
+      initialize: vi.fn()
+    }
+
+    const manager = new LanguageManager(loader, translationService, gameDataProvider)
+    await expect(manager.setLanguage('unknown')).rejects.toThrow('[LanguageManager] Unknown language key: unknown')
+  })
+})


### PR DESCRIPTION
## Summary
- Ensure LanguageManager throws an error when an undefined language key is requested
- Add unit test for invalid language keys

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b262aa1f883329aa3171337541685