### PR TITLE
Fix MessageQueue reprocessing of new messages

### DIFF
--- a/tests/engine/messageQueue.test.ts
+++ b/tests/engine/messageQueue.test.ts
@@ -79,5 +79,23 @@ describe('MessageQueue', () => {
     expect(order).toEqual(['a', 'b'])
     expect(onEmpty).toHaveBeenCalledTimes(1)
   })
+
+  it('reprocesses messages posted during draining before calling onQueueEmpty', async () => {
+    const onEmpty = vi.fn()
+    const queue = new MessageQueue(onEmpty)
+    const handled: string[] = []
+    queue.setHandler(m => {
+      handled.push(m.message)
+      if (m.message === 'a') {
+        queue.postMessage({ message: 'b', payload: null })
+      }
+    })
+
+    queue.postMessage({ message: 'a', payload: null })
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(handled).toEqual(['a', 'b'])
+    expect(onEmpty).toHaveBeenCalledTimes(1)
+  })
 })
 

--- a/utils/messageQueue.ts
+++ b/utils/messageQueue.ts
@@ -57,6 +57,9 @@ export class MessageQueue implements IMessageQueue {
         } finally {
             this.emptyingQueue = false
         }
+        if (this.queue.length > 0) {
+            return this.emptyQueue()
+        }
         this.onQueueEmpty()
     }
 


### PR DESCRIPTION
## Summary
- rerun emptyQueue when new messages arrive during draining
- add unit test for messages posted mid-drain

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b2619f47c83328cae5d77519e5b90