### PR TITLE
prevent provider override

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ npm run build    # production build
 1. Fork the repository and create feature branches for your work.
 2. Ensure code adheres to the project's linting rules and passes all tests.
 3. Submit a pull request with a clear description of your changes.
+4. Avoid registering the same token twice in the IoC container; doing so throws an error and the original provider remains in place.
 
 ## License
 This project is licensed under the [MPL-2.0](LICENSE).

--- a/engine/ioc/container.ts
+++ b/engine/ioc/container.ts
@@ -1,6 +1,6 @@
 import { describeToken, type Token } from './token'
 import type { Provider, Scope } from './types'
-import { logWarning } from '@utils/logMessage'
+import { fatalError } from '@utils/logMessage'
 
 const logName: string = 'Container'
 
@@ -18,7 +18,7 @@ export class Container {
 
   register<T>(provider: Provider<T>): this {
     if (this.providers.has(provider.token)) {
-      logWarning(logName, 'Provider for {0} already registered', describeToken(provider.token))
+      fatalError(logName, 'Provider for {0} already registered', describeToken(provider.token))
     }
     this.providers.set(provider.token, provider)
     return this

--- a/tests/engine/container.test.ts
+++ b/tests/engine/container.test.ts
@@ -1,7 +1,6 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect } from 'vitest'
 import { Container } from '@ioc/container'
 import { token } from '@ioc/token'
-import * as logging from '@utils/logMessage'
 
 describe('IoC Container', () => {
   it('resolves registered dependencies', () => {
@@ -54,13 +53,11 @@ describe('IoC Container', () => {
     expect(() => c.resolve(A_TOKEN)).toThrowError(/IoC circular dependency/)
   })
 
-  it('warns when registering the same token twice', () => {
+  it('throws and does not override when registering the same token twice', () => {
     const FOO = token<number>('foo')
-    const warn = vi.spyOn(logging, 'logWarning').mockImplementation(() => '')
     const c = new Container()
     c.register({ token: FOO, useValue: 1 })
-    c.register({ token: FOO, useValue: 2 })
-    expect(warn).toHaveBeenCalled()
-    warn.mockRestore()
+    expect(() => c.register({ token: FOO, useValue: 2 })).toThrowError(/already registered/)
+    expect(c.resolve(FOO)).toBe(1)
   })
 })


### PR DESCRIPTION
## Summary
- avoid overriding providers in the IoC container by throwing a fatal error on duplicate registration
- document the duplicate registration behavior
- test that duplicate registration throws and retains original provider

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b263aad3083329c22fa019f0881a8