### PR TITLE
Handle empty language paths in LanguageLoader

### DIFF
--- a/engine/loader/languageLoader.ts
+++ b/engine/loader/languageLoader.ts
@@ -14,12 +14,18 @@ export const languageLoaderDependencies: Token<unknown>[] = [dataPathProviderTok
 export class LanguageLoader implements ILanguageLoader {
     constructor(private basePathProvider: IDataPathProvider) {
     }
-    
+
     public async loadLanguage(paths: string[]): Promise<LanguageData> {
-        const schemas = await Promise.all(paths.map(path => loadJsonResource<Language>(`${this.basePathProvider.dataPath}/${path}`, languageSchema)))
+        if (paths.length === 0) {
+            throw new Error('[LanguageLoader] No language paths provided')
+        }
+
+        const schemas = await Promise.all(
+            paths.map(path => loadJsonResource<Language>(`${this.basePathProvider.dataPath}/${path}`, languageSchema))
+        )
         const languages = schemas.map(mapLanguage)
         return {
-            id: languages[0].id,
+            id: languages[0]?.id ?? '',
             translations: languages.reduce((acc, lang) => {
                 return { ...acc, ...lang.translations }
             }, {})

--- a/tests/engine/languageManager.test.ts
+++ b/tests/engine/languageManager.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { LanguageManager } from '../../engine/managers/languageManager'
-import type { ILanguageLoader } from '../../engine/loader/languageLoader'
+import { LanguageLoader, type ILanguageLoader } from '../../engine/loader/languageLoader'
 import type { ITranslationService } from '../../engine/services/translationService'
 import type { IGameDataProvider, GameData, GameContext } from '../../engine/providers/gameDataProvider'
 import type { Language } from '@loader/data/language'
@@ -15,7 +15,7 @@ describe('LanguageManager', () => {
     }
     const gameData = {
       game: { languages: {} } as unknown as Game,
-      languages: {} as Record<string, Language>
+      loadedLanguages: {} as Record<string, Language>
     } as unknown as GameData
     const context = {} as unknown as GameContext
     const gameDataProvider: IGameDataProvider = {
@@ -30,5 +30,30 @@ describe('LanguageManager', () => {
 
     const manager = new LanguageManager(loader, translationService, gameDataProvider)
     await expect(manager.setLanguage('unknown')).rejects.toThrow('[LanguageManager] Unknown language key: unknown')
+  })
+
+  it('throws when language paths are empty', async () => {
+    const loader = new LanguageLoader({ dataPath: '' })
+    const translationService: ITranslationService = {
+      translate: vi.fn(),
+      setLanguage: vi.fn()
+    }
+    const gameData = {
+      game: { languages: { empty: [] } } as unknown as Game,
+      loadedLanguages: {} as Record<string, Language>
+    } as unknown as GameData
+    const context = {} as unknown as GameContext
+    const gameDataProvider: IGameDataProvider = {
+      get Game() {
+        return gameData
+      },
+      get Context() {
+        return context
+      },
+      initialize: vi.fn()
+    }
+
+    const manager = new LanguageManager(loader, translationService, gameDataProvider)
+    await expect(manager.setLanguage('empty')).rejects.toThrow('[LanguageLoader] No language paths provided')
   })
 })


### PR DESCRIPTION
## Summary
- Add validation for empty language path arrays and safer return logic
- Test LanguageManager behavior when language path list is empty

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_689b8b4481e083328c09b32f560672c2