### PR TITLE
fix: remove trailing spaces from language joins

### DIFF
--- a/engine/loader/mappers/language.ts
+++ b/engine/loader/mappers/language.ts
@@ -7,7 +7,7 @@ export function mapLanguage(language: Language): LanguageData {
         translations: Object.fromEntries(
             Object.entries(language.translations).map(([key, value]) => [
                 key,
-                Array.isArray(value) ? value.join("\n ") : value
+                Array.isArray(value) ? value.join("\n") : value
             ])
         )
     }

--- a/tests/engine/mappers.test.ts
+++ b/tests/engine/mappers.test.ts
@@ -43,9 +43,10 @@ describe('Loader mappers', () => {
       id: 'en',
       translations: {
         greeting: 'Hello',
-        multiline: 'line1\n line2'
+        multiline: 'line1\nline2'
       }
     })
+    expect(result.translations.multiline).not.toContain('\n ')
   })
 
   it('maps condition data', () => {


### PR DESCRIPTION
## Summary
- trim trailing spaces when joining language translations
- test joined translations to ensure no trailing spaces

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b8b87a184833289bedf379faa2d2f