### PR TITLE
feat: handle errors when draining message queue

### DIFF
--- a/utils/messageQueue.ts
+++ b/utils/messageQueue.ts
@@ -1,5 +1,6 @@
 import { token } from '@ioc/token'
 import type { Message } from './types'
+import { logWarning } from './logMessage'
 
 export interface IMessageQueue {
     postMessage(message: Message): void
@@ -10,7 +11,8 @@ export interface IMessageQueue {
     shutDown(): void
 }
 
-export const messageQueueToken = token<IMessageQueue>('MessageQueue')
+const logName = 'MessageQueue'
+export const messageQueueToken = token<IMessageQueue>(logName)
 export class MessageQueue implements IMessageQueue {
     private queue: Message[] = []
     private emptyingQueue = false
@@ -51,7 +53,11 @@ export class MessageQueue implements IMessageQueue {
                 if (!message) continue
                 const result = this.handler(message)
                 if (result && typeof (result as PromiseLike<unknown>).then === 'function') {
-                    await result
+                    try {
+                        await result
+                    } catch (err) {
+                        logWarning(logName, 'Error processing message {0}: {1}', message.message, err)
+                    }
                 }
             }
         } finally {


### PR DESCRIPTION
## Summary
- log warnings for message handling errors
- continue emptying queue even if a message handler fails

## Testing
- `npm run build`
- `npm run lint`
- `npm run test` *(fails: No provider for EngineInitializer)*

------
https://chatgpt.com/codex/tasks/task_e_689c8d783a7c8332a6722a9ffe0a0fa5