### PR TITLE
Validate language IDs in loader

### DIFF
--- a/engine/loader/languageLoader.ts
+++ b/engine/loader/languageLoader.ts
@@ -24,8 +24,15 @@ export class LanguageLoader implements ILanguageLoader {
             paths.map(path => loadJsonResource<Language>(`${this.basePathProvider.dataPath}/${path}`, languageSchema))
         )
         const languages = schemas.map(mapLanguage)
+
+        const sharedId = languages[0].id
+        const mismatched = languages.find(lang => lang.id !== sharedId)
+        if (mismatched) {
+            throw new Error(`[LanguageLoader] Language ID mismatch: expected ${sharedId} but got ${mismatched.id}`)
+        }
+
         return {
-            id: languages[0]?.id ?? '',
+            id: sharedId,
             translations: languages.reduce((acc, lang) => {
                 return { ...acc, ...lang.translations }
             }, {})

--- a/engine/main.tsx
+++ b/engine/main.tsx
@@ -8,7 +8,7 @@ import { turnSchedulerToken } from '@engine/turnScheduler'
 import './styling/reset.css'
 import './styling/variables.css'
 import './styling/engine.css'
-import { App } from '@app/app'
+import { App } from '@app/App'
 
 const dataPath = import.meta.env.VITE_DATA_PATH ?? '/data'
 const containerBuilder: IContainerBuilder = new ContainerBuilder(


### PR DESCRIPTION
## Summary
- ensure all loaded language files share the same id
- fix App import casing so build resolves module

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_689cb15af4b483329a9edbacea64e4e9