### PR TITLE
Handle empty queue errors gracefully

### DIFF
--- a/utils/messageQueue.ts
+++ b/utils/messageQueue.ts
@@ -66,7 +66,11 @@ export class MessageQueue implements IMessageQueue {
         if (this.queue.length > 0) {
             return this.emptyQueue()
         }
-        this.onQueueEmpty()
+        try {
+            this.onQueueEmpty()
+        } catch (err) {
+            logWarning(logName, 'Error handling empty queue: {0}', err)
+        }
     }
 
     public shutDown(): void {


### PR DESCRIPTION
## Summary
- prevent queue-empty errors from breaking processing

## Testing
- `npm run lint`
- `npm run test`
- `npm run build` *(fails: Cannot find module '@app/app')*

------
https://chatgpt.com/codex/tasks/task_e_689cb166811c833286bf32e2fb97ccac