### PR TITLE
test: add scheduler and page manager tests

### DIFF
--- a/tests/engine/pageManager.test.ts
+++ b/tests/engine/pageManager.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from 'vitest'
+import { PageManager } from '../../engine/managers/pageManager'
+import { SWITCH_PAGE, PAGE_SWITCHED } from '../../engine/messages/system'
+import type { IMessageBus } from '../../utils/messageBus'
+import type { IGameDataProvider, GameData, GameContext } from '../../engine/providers/gameDataProvider'
+import type { IPageLoader } from '../../engine/loader/pageLoader'
+
+type Msg = { message: string, payload: unknown }
+
+function createBus(): IMessageBus {
+  const listeners = new Map<string, ((m: Msg) => void)[]>()
+  const postMessage = vi.fn((msg: Msg) => {
+    (listeners.get(msg.message) || []).forEach(h => h(msg))
+  })
+  const registerMessageListener = vi.fn((message: string, handler: (msg: Msg) => void) => {
+    if (!listeners.has(message)) listeners.set(message, [])
+    listeners.get(message)!.push(handler)
+    return () => {
+      const arr = listeners.get(message)!.filter(h => h !== handler)
+      if (arr.length > 0) listeners.set(message, arr)
+      else listeners.delete(message)
+    }
+  })
+  return { postMessage, registerMessageListener } as unknown as IMessageBus
+}
+
+describe('PageManager', () => {
+  it('loads pages and posts switch messages', async () => {
+    const bus = createBus()
+    const gameData = {
+      game: { pages: { home: 'home.json' } },
+      loadedLanguages: {},
+      loadedPages: {} as Record<string, unknown>
+    } as unknown as GameData
+    const context = { currentPageId: null } as unknown as GameContext
+    const provider = {
+      get Game() { return gameData },
+      get Context() { return context },
+      initialize: vi.fn()
+    } as unknown as IGameDataProvider
+    const loadPage = vi.fn().mockResolvedValue({ id: 'home' })
+    const loader = { loadPage } as unknown as IPageLoader
+    const manager = new PageManager(provider, loader, bus)
+
+    await manager.setActivePage('home')
+
+    expect(loadPage).toHaveBeenCalledWith('home.json')
+    expect(gameData.loadedPages['home']).toEqual({ id: 'home' })
+    expect(context.currentPageId).toBe('home')
+    expect(bus.postMessage).toHaveBeenCalledWith({ message: PAGE_SWITCHED, payload: 'home' })
+  })
+
+  it('responds to SWITCH_PAGE messages and cleans up listeners', async () => {
+    const bus = createBus()
+    const provider = {} as IGameDataProvider
+    const loader = {} as IPageLoader
+    const manager = new PageManager(provider, loader, bus)
+    const spy = vi.spyOn(manager, 'setActivePage').mockResolvedValue(undefined)
+
+    bus.postMessage({ message: SWITCH_PAGE, payload: 'home' })
+    await Promise.resolve()
+    expect(spy).toHaveBeenCalledWith('home')
+
+    manager.cleanup()
+    bus.postMessage({ message: SWITCH_PAGE, payload: 'home' })
+    await Promise.resolve()
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/engine/turnScheduler.test.ts
+++ b/tests/engine/turnScheduler.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from 'vitest'
+import { TurnScheduler } from '../../engine/engine/turnScheduler'
+import { START_END_TURN_MESSAGE, FINALIZE_END_TURN_MESSAGE } from '../../engine/messages/system'
+import type { IMessageBus } from '../../utils/messageBus'
+
+describe('TurnScheduler', () => {
+  it('transitions state on successive empty queue events', () => {
+    const postMessage = vi.fn()
+    const bus = { postMessage } as unknown as IMessageBus
+    const scheduler = new TurnScheduler(bus)
+
+    // first event: start ending turn
+    scheduler.onQueueEmpty()
+    expect(postMessage).toHaveBeenCalledTimes(1)
+    expect(postMessage).toHaveBeenLastCalledWith({ message: START_END_TURN_MESSAGE, payload: null })
+
+    // second event: finalize turn
+    scheduler.onQueueEmpty()
+    expect(postMessage).toHaveBeenCalledTimes(2)
+    expect(postMessage).toHaveBeenLastCalledWith({ message: FINALIZE_END_TURN_MESSAGE, payload: null })
+
+    // third event: no message, reset
+    scheduler.onQueueEmpty()
+    expect(postMessage).toHaveBeenCalledTimes(2)
+
+    // fourth event: cycle restarts with start message
+    scheduler.onQueueEmpty()
+    expect(postMessage).toHaveBeenCalledTimes(3)
+    expect(postMessage).toHaveBeenLastCalledWith({ message: START_END_TURN_MESSAGE, payload: null })
+  })
+})


### PR DESCRIPTION
## Summary
- add tests for turn scheduler state cycle
- add tests for page manager loading and listener cleanup

## Testing
- `npm run lint`
- `npm run build`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_689cbbe8ec8c8332a62f14cc27d86de1