### PR TITLE
fix: disable no-undef for TypeScript

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,7 +9,7 @@ export default [
   },
   js.configs.recommended,
   {
-    files: ['**/*.{ts,tsx,js,jsx}'],
+    files: ['**/*.{ts,tsx}'],
     languageOptions: {
       parser: tsParser,
       parserOptions: {
@@ -27,6 +27,8 @@ export default [
     },
     rules: {
       ...tsPlugin.configs.recommended.rules,
+      // Rely on TypeScript for undefined variable checks
+      'no-undef': 'off',
       'eol-last': ['error', 'always'],
     },
   },


### PR DESCRIPTION
## Summary
- disable no-undef for TypeScript sources so React typings don't trigger lint errors

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_689cd83cf75c833294468d3d692be000