### PR TITLE
Add default case for unsupported screen types

### DIFF
--- a/engine/app/controls/screen/screen.tsx
+++ b/engine/app/controls/screen/screen.tsx
@@ -1,15 +1,21 @@
 import { Screen as ScreenData } from '@loader/data/page'
 import { Grid } from './grid'
+import { logWarning } from '@utils/logMessage'
 
 interface ScreenProps {
     screen: ScreenData
 }
 
-export const Screen: React.FC<ScreenProps> = ({ screen }): React.JSX.Element => {
+const logName = 'Screen'
+
+export const Screen: React.FC<ScreenProps> = ({ screen }): React.JSX.Element | null => {
     switch (screen.type) {
         case 'grid':
             return (
                 <Grid screen={screen} />
             )
+        default:
+            logWarning(logName, 'Unsupported screen type: {0}', screen.type)
+            return null
     }
 }


### PR DESCRIPTION
## Summary
- log warning for unsupported `screen.type`
- return null when screen type is unknown

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_689d23d6f7448332b9ae48eb28d68bf9