### PR TITLE
feat: add action handler registry for DI-driven handlers

### DIFF
--- a/engine/builders/containerBuilder.ts
+++ b/engine/builders/containerBuilder.ts
@@ -15,6 +15,7 @@ import { DomManager, domManagerDependencies, domManagerToken } from '@managers/d
 import { LanguageManager, languageManagerDependencies, languageManagerToken } from '@managers/languageManager'
 import { PageManager, pageManagerDependencies, pageManagerToken } from '@managers/pageManager'
 import { IServiceProvider, ServiceProvider, serviceProviderToken } from '@providers/serviceProvider'
+import { ActionHandlerRegistry, actionHandlerRegistryToken } from '@registries/actionHandlerRegistry'
 
 export interface IContainerBuilder {
     build(): Container
@@ -32,6 +33,7 @@ export class ContainerBuilder implements IContainerBuilder {
         this.registerProviders(result)
         this.registerLoaders(result)
         this.registerServices(result)
+        this.registerRegistries(result)
         this.registerManagers(result)
         // Register other dependencies as needed
         return result
@@ -103,6 +105,13 @@ export class ContainerBuilder implements IContainerBuilder {
             token: translationServiceToken,
             useClass: TranslationService,
             deps: []
+        })
+    }
+
+    private registerRegistries(container: Container): void {
+        container.register({
+            token: actionHandlerRegistryToken,
+            useClass: ActionHandlerRegistry
         })
     }
 

--- a/engine/registries/actionHandlerRegistry.ts
+++ b/engine/registries/actionHandlerRegistry.ts
@@ -1,7 +1,71 @@
 import { Action, BaseAction } from '@loader/data/action'
 import { Message } from '@utils/types'
+import { token, type Token } from '@ioc/token'
+import type { IServiceProvider } from '@providers/serviceProvider'
 
+/**
+ * Represents a handler for a specific {@link Action} type.
+ *
+ * Individual handlers will implement this interface and are registered using
+ * {@link ActionHandlerRegistry.registerActionHandler}. The registry keeps a mapping of an action
+ * type to the IoC {@link Token} of its handler. When an instance is required
+ * the token is resolved via the {@link IServiceProvider}.
+ */
 export interface IActionHandler<T extends BaseAction = Action> {
+    /** The action type this handler is responsible for. */
     readonly type: T['type']
+    /**
+     * Handles the provided action.
+     *
+     * @param action - The action instance to handle
+     * @param message - Optional message context
+     * @param data - Optional additional data
+     */
     handle(action: T, message?: Message, data?: unknown): void
+}
+
+// ---------------------------------------------------------------------------
+// Registry implementation
+
+/**
+ * Registry responsible for mapping action types to handler tokens and
+ * resolving handler instances via an {@link IServiceProvider}.
+ */
+export const actionHandlerRegistryToken = token<ActionHandlerRegistry>('ActionHandlerRegistry')
+
+export class ActionHandlerRegistry {
+    private readonly registry = new Map<string, Token<IActionHandler>>()
+
+    /**
+     * Registers an action handler token for a given action type.
+     *
+     * @param type - The action type handled by the token
+     * @param handlerToken - IoC token used to resolve the handler
+     */
+    public registerActionHandler<T extends BaseAction>(
+        type: T['type'],
+        handlerToken: Token<IActionHandler<T>>
+    ): void {
+        this.registry.set(type, handlerToken as Token<IActionHandler>)
+    }
+
+    /**
+     * Resolves an action handler instance for the specified action type.
+     *
+     * @param type - The action type to resolve a handler for
+     * @param serviceProvider - Service provider used to resolve the handler
+     * @returns The handler instance or `undefined` if no handler is registered
+     */
+    public getActionHandler<T extends BaseAction>(
+        type: T['type'],
+        serviceProvider: IServiceProvider
+    ): IActionHandler<T> | undefined {
+        const token = this.registry.get(type)
+        return token ? (serviceProvider.getService(token) as unknown as IActionHandler<T>) : undefined
+    }
+
+    /** Clears all registered handlers. */
+    public clear(): void {
+        this.registry.clear()
+    }
 }

--- a/tests/engine/actionHandlerRegistry.test.ts
+++ b/tests/engine/actionHandlerRegistry.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { ActionHandlerRegistry, actionHandlerRegistryToken, IActionHandler } from '@registries/actionHandlerRegistry'
+import { token } from '@ioc/token'
+import { Container } from '@ioc/container'
+import { ServiceProvider } from '@providers/serviceProvider'
+import type { PostMessageAction } from '@loader/data/action'
+
+class TestHandler implements IActionHandler<PostMessageAction> {
+    public readonly type = 'post-message'
+    public handled: PostMessageAction | undefined
+    handle(action: PostMessageAction): void {
+        this.handled = action
+    }
+}
+
+describe('ActionHandlerRegistry', () => {
+    let registry: ActionHandlerRegistry
+    let serviceProvider: ServiceProvider
+    let container: Container
+
+    beforeEach(() => {
+        container = new Container()
+        container.register({ token: actionHandlerRegistryToken, useClass: ActionHandlerRegistry })
+        registry = container.resolve(actionHandlerRegistryToken)
+        registry.clear()
+        serviceProvider = new ServiceProvider(container)
+    })
+
+    it('provides handler instance via service provider', () => {
+        const HANDLER = token<IActionHandler<PostMessageAction>>('handler')
+        container.register({ token: HANDLER, useClass: TestHandler })
+
+        registry.registerActionHandler('post-message', HANDLER)
+        const handler = registry.getActionHandler('post-message', serviceProvider)
+        expect(handler).toBeInstanceOf(TestHandler)
+    })
+
+    it('returns undefined when no handler registered for type', () => {
+        const handler = registry.getActionHandler('missing', serviceProvider)
+        expect(handler).toBeUndefined()
+    })
+})


### PR DESCRIPTION
## Summary
- add registry to register action handlers by type and resolve them through IoC service provider
- cover action handler registry with unit tests
- encapsulate registry logic in `ActionHandlerRegistry` class
- register `ActionHandlerRegistry` with the IoC container for singleton access

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d925230708332b96dc4c0f3a7d1c0