### PR TITLE
feat: add interface for action handler registry

### DIFF
--- a/engine/builders/containerBuilder.ts
+++ b/engine/builders/containerBuilder.ts
@@ -15,7 +15,7 @@ import { DomManager, domManagerDependencies, domManagerToken } from '@managers/d
 import { LanguageManager, languageManagerDependencies, languageManagerToken } from '@managers/languageManager'
 import { PageManager, pageManagerDependencies, pageManagerToken } from '@managers/pageManager'
 import { IServiceProvider, ServiceProvider, serviceProviderToken } from '@providers/serviceProvider'
-import { ActionHandlerRegistry, actionHandlerRegistryToken } from '@registries/actionHandlerRegistry'
+import { ActionHandlerRegistry, actionHandlerRegistryToken, IActionHandlerRegistry } from '@registries/actionHandlerRegistry'
 
 export interface IContainerBuilder {
     build(): Container
@@ -109,7 +109,7 @@ export class ContainerBuilder implements IContainerBuilder {
     }
 
     private registerRegistries(container: Container): void {
-        container.register({
+        container.register<IActionHandlerRegistry>({
             token: actionHandlerRegistryToken,
             useClass: ActionHandlerRegistry
         })

--- a/engine/registries/actionHandlerRegistry.ts
+++ b/engine/registries/actionHandlerRegistry.ts
@@ -31,9 +31,15 @@ export interface IActionHandler<T extends BaseAction = Action> {
  * Registry responsible for mapping action types to handler tokens and
  * resolving handler instances via an {@link IServiceProvider}.
  */
-export const actionHandlerRegistryToken = token<ActionHandlerRegistry>('ActionHandlerRegistry')
+export interface IActionHandlerRegistry {
+    registerActionHandler<T extends BaseAction>(type: T['type'], handlerToken: Token<IActionHandler<T>>): void
+    getActionHandler<T extends BaseAction>(type: T['type'], serviceProvider: IServiceProvider): IActionHandler<T> | undefined
+    clear(): void
+}
 
-export class ActionHandlerRegistry {
+export const actionHandlerRegistryToken = token<IActionHandlerRegistry>('ActionHandlerRegistry')
+
+export class ActionHandlerRegistry implements IActionHandlerRegistry {
     private readonly registry = new Map<string, Token<IActionHandler>>()
 
     /**

--- a/tests/engine/actionHandlerRegistry.test.ts
+++ b/tests/engine/actionHandlerRegistry.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest'
-import { ActionHandlerRegistry, actionHandlerRegistryToken, IActionHandler } from '@registries/actionHandlerRegistry'
+import { ActionHandlerRegistry, actionHandlerRegistryToken, IActionHandler, IActionHandlerRegistry } from '@registries/actionHandlerRegistry'
 import { token } from '@ioc/token'
 import { Container } from '@ioc/container'
 import { ServiceProvider } from '@providers/serviceProvider'
@@ -14,13 +14,13 @@ class TestHandler implements IActionHandler<PostMessageAction> {
 }
 
 describe('ActionHandlerRegistry', () => {
-    let registry: ActionHandlerRegistry
+    let registry: IActionHandlerRegistry
     let serviceProvider: ServiceProvider
     let container: Container
 
     beforeEach(() => {
         container = new Container()
-        container.register({ token: actionHandlerRegistryToken, useClass: ActionHandlerRegistry })
+        container.register<IActionHandlerRegistry>({ token: actionHandlerRegistryToken, useClass: ActionHandlerRegistry })
         registry = container.resolve(actionHandlerRegistryToken)
         registry.clear()
         serviceProvider = new ServiceProvider(container)


### PR DESCRIPTION
## Summary
- add IActionHandlerRegistry and token tied to interface
- use interface when registering action handler registry in container builder
- update tests to resolve registry via interface

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_689d9c2ce2b8833291b1b35a88eb62e8