### PR TITLE
docs: document component registry

### DIFF
--- a/engine/registries/componentRegistry.ts
+++ b/engine/registries/componentRegistry.ts
@@ -1,14 +1,34 @@
+/**
+ * Central registry for mapping string identifiers to React components.
+ *
+ * The registry enables dynamic component rendering by allowing components to
+ * be looked up and extended at runtime. New components can be registered
+ * using {@link registerComponent} and later retrieved from
+ * {@link componentRegistry} by their type key.
+ */
 import { GameMenuComponent } from '@app/controls/component/gameMenuComponent'
 import { ImageComponent } from '@app/controls/component/imageComponent'
 import { ComponentType } from 'react'
 
+/**
+ * Holds the mapping between component type strings and their React
+ * implementations. Consumers can query this registry to render components
+ * dynamically based on their type.
+ */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const componentRegistry: Record<string, ComponentType<any>> = {
     'image': ImageComponent,
     'game-menu': GameMenuComponent
 }
 
+/**
+ * Registers a new component under the specified type key.
+ *
+ * @param type - Unique string used to reference the component.
+ * @param component - React component associated with the given type.
+ */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const registerComponent = (type: string, component: ComponentType<any>):void => {
+export const registerComponent = (type: string, component: ComponentType<any>): void => {
     componentRegistry[type] = component
 }
+


### PR DESCRIPTION
## Summary
- add file-level overview for component registry
- document `componentRegistry` mapping and `registerComponent` helper

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_689da0d35f6483329f48117689888820