### PR TITLE
docs: document container builder registration methods

### DIFF
--- a/engine/builders/containerBuilder.ts
+++ b/engine/builders/containerBuilder.ts
@@ -17,16 +17,37 @@ import { PageManager, pageManagerDependencies, pageManagerToken } from '@manager
 import { IServiceProvider, ServiceProvider, serviceProviderToken } from '@providers/serviceProvider'
 import { ActionHandlerRegistry, actionHandlerRegistryToken, IActionHandlerRegistry } from '@registries/actionHandlerRegistry'
 
+/**
+ * Builder abstraction for creating and configuring a dependency injection container.
+ */
 export interface IContainerBuilder {
+    /**
+     * Construct and configure a service container.
+     *
+     * @returns A fully configured container instance.
+     */
     build(): Container
 }
 
+/**
+ * Wires together all engine components using dependency injection.
+ */
 export class ContainerBuilder implements IContainerBuilder {
+    /**
+     * @param onQueueEmptyProvider Factory for creating callbacks when the message queue empties.
+     * @param dataPath Base path for loading game data resources.
+     */
     constructor(
         private onQueueEmptyProvider: (container: IContainer) => () => void = () => () => {},
         private dataPath: string = process.env.DATA_PATH ?? '/data',
     ) {}
 
+    /**
+     * Build and configure the dependency container.
+     *
+     * @returns Populated container instance.
+     * @remarks Mutates the new container by registering all engine services.
+     */
     public build(): Container {
         const result = new Container()
         this.registerCore(result)
@@ -39,6 +60,12 @@ export class ContainerBuilder implements IContainerBuilder {
         return result
     }
 
+    /**
+     * Register core engine dependencies such as scheduler and message systems.
+     *
+     * @param container Container to receive registrations.
+     * @remarks Mutates the provided container.
+     */
     private registerCore(container: Container): void {
         container.register({
             token: turnSchedulerToken,
@@ -66,6 +93,12 @@ export class ContainerBuilder implements IContainerBuilder {
         })
     }
 
+    /**
+     * Register provider-related services like configuration and data providers.
+     *
+     * @param container Container to receive registrations.
+     * @remarks Mutates the provided container.
+     */
     private registerProviders(container: Container): void {
         container.register<IServiceProvider>({
             token: serviceProviderToken,
@@ -82,6 +115,12 @@ export class ContainerBuilder implements IContainerBuilder {
         })
     }
 
+    /**
+     * Register loaders responsible for fetching game, language and page data.
+     *
+     * @param container Container to receive registrations.
+     * @remarks Mutates the provided container.
+     */
     private registerLoaders(container: Container): void {
         container.register<IGameLoader>({
             token: gameLoaderToken,
@@ -100,6 +139,12 @@ export class ContainerBuilder implements IContainerBuilder {
         })
     }
 
+    /**
+     * Register application services such as translation.
+     *
+     * @param container Container to receive registrations.
+     * @remarks Mutates the provided container.
+     */
     private registerServices(container: Container): void {
         container.register({
             token: translationServiceToken,
@@ -108,6 +153,12 @@ export class ContainerBuilder implements IContainerBuilder {
         })
     }
 
+    /**
+     * Register registries used for dynamic lookups such as action handlers.
+     *
+     * @param container Container to receive registrations.
+     * @remarks Mutates the provided container.
+     */
     private registerRegistries(container: Container): void {
         container.register<IActionHandlerRegistry>({
             token: actionHandlerRegistryToken,
@@ -115,6 +166,12 @@ export class ContainerBuilder implements IContainerBuilder {
         })
     }
 
+    /**
+     * Register manager classes that orchestrate DOM, language and pages.
+     *
+     * @param container Container to receive registrations.
+     * @remarks Mutates the provided container.
+     */
     private registerManagers(container: Container): void {
         container.register({
             token: domManagerToken,


### PR DESCRIPTION
## Summary
- add JSDoc for IContainerBuilder and ContainerBuilder
- document registration methods with parameter and side-effect details

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_689da4934ad883328eecfeabb70d0450