### PR TITLE
docs(domManager): clarify setCssFile behavior

### DIFF
--- a/engine/managers/domManager.ts
+++ b/engine/managers/domManager.ts
@@ -51,8 +51,8 @@ export class DomManager implements IDomManager {
     }
 
     /**
-     * Appends a CSS file to the document head if it has not already been
-     * inserted.
+     * Appends a CSS file to the document head, avoiding re-insertion if the
+     * file has already been added to the document.
      *
      * @param path - Path of the style sheet to include.
      */


### PR DESCRIPTION
## Summary
- document DomManager.setCssFile to explicitly mention it skips already-added CSS files

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_689daa591d208332a8d45c99e553e1fb