### PR TITLE
Process queued messages when handler is set

### DIFF
--- a/tests/engine/messageQueue.test.ts
+++ b/tests/engine/messageQueue.test.ts
@@ -19,6 +19,24 @@ describe('MessageQueue', () => {
     expect(onEmpty).toHaveBeenCalledTimes(2)
   })
 
+  it('processes queued messages after handler is set', async () => {
+    const onEmpty = vi.fn()
+    const queue = new MessageQueue(onEmpty)
+    const handled: Message[] = []
+
+    queue.postMessage({ message: 'a', payload: null })
+    queue.postMessage({ message: 'b', payload: 1 })
+
+    queue.setHandler(m => {
+      handled.push(m)
+    })
+
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(handled.map(m => m.message)).toEqual(['a', 'b'])
+    expect(onEmpty).toHaveBeenCalledTimes(1)
+  })
+
   it('queues messages when auto-drain disabled and drains when enabled', async () => {
     const onEmpty = vi.fn()
     const queue = new MessageQueue(onEmpty)

--- a/utils/messageQueue.ts
+++ b/utils/messageQueue.ts
@@ -68,6 +68,7 @@ export class MessageQueue implements IMessageQueue {
      */
     public setHandler(handler: (message: Message) => void | Promise<void>): void {
         this.handler = handler
+        void this.emptyQueue()
     }
 
     /**


### PR DESCRIPTION
## Summary
- drain message queue immediately after a handler is registered
- add regression test for processing queued messages when handler becomes available

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_689dafd0e9648332b033c6002bacabb1