### PR TITLE
Refactor component registry to DI-backed class

### DIFF
--- a/engine/app/controls/component/component.tsx
+++ b/engine/app/controls/component/component.tsx
@@ -1,6 +1,7 @@
 import { Component as ComponentData } from '@loader/data/component'
 import { logWarning } from '@utils/logMessage'
-import { componentRegistry } from '@registries/componentRegistry'
+import { IComponentRegistry, componentRegistryToken } from '@registries/componentRegistry'
+import { useService } from '@app/iocProvider'
 
 interface ComponentProps {
     component: ComponentData
@@ -13,8 +14,9 @@ const DefaultComponent: React.FC<ComponentProps> = ({ component }): React.JSX.El
     )
 }
 
-export const Component: React.FC<ComponentProps> = ({ component}): React.JSX.Element => {
-    const ComponentImpl = componentRegistry[component.type] ?? DefaultComponent
+export const Component: React.FC<ComponentProps> = ({ component }): React.JSX.Element => {
+    const registry = useService<IComponentRegistry>(componentRegistryToken)
+    const ComponentImpl = registry.getComponent(component.type) ?? DefaultComponent
     return (
         <ComponentImpl component={component} />
     )

--- a/engine/builders/containerBuilder.ts
+++ b/engine/builders/containerBuilder.ts
@@ -17,6 +17,7 @@ import { PageManager, pageManagerDependencies, pageManagerToken } from '@manager
 import { IServiceProvider, ServiceProvider, serviceProviderToken } from '@providers/serviceProvider'
 import { ActionHandlerRegistry, actionHandlerRegistryDependencies, actionHandlerRegistryToken, IActionHandlerRegistry } from '@registries/actionHandlerRegistry'
 import { ConditionResolverRegistry, conditionResolverRegistryDependencies, conditionResolverRegistryToken, IConditionResolverRegistry } from '@registries/conditionResolverRegistry'
+import { ComponentRegistry, componentRegistryDependencies, componentRegistryToken, IComponentRegistry } from '@registries/componentRegistry'
 
 /**
  * Builder abstraction for creating and configuring a dependency injection container.
@@ -171,6 +172,11 @@ export class ContainerBuilder implements IContainerBuilder {
             token: conditionResolverRegistryToken,
             useClass: ConditionResolverRegistry,
             deps: conditionResolverRegistryDependencies
+        })
+        container.register<IComponentRegistry>({
+            token: componentRegistryToken,
+            useClass: ComponentRegistry,
+            deps: componentRegistryDependencies
         })
     }
 

--- a/engine/registries/componentRegistry.ts
+++ b/engine/registries/componentRegistry.ts
@@ -2,40 +2,52 @@
  * Central registry for mapping string identifiers to React components.
  *
  * The registry enables dynamic component rendering by allowing components to
- * be looked up and extended at runtime. New components can be registered
- * using {@link registerComponent} and later retrieved from
- * {@link componentRegistry} by their type key.
+ * be looked up and extended at runtime.
  */
 import { GameMenuComponent } from '@app/controls/component/gameMenuComponent'
 import { ImageComponent } from '@app/controls/component/imageComponent'
 import { ComponentType } from 'react'
 import { logWarning } from '@utils/logMessage'
+import { token, Token } from '@ioc/token'
 
-/**
- * Holds the mapping between component type strings and their React
- * implementations. Consumers can query this registry to render components
- * dynamically based on their type.
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const componentRegistry: Record<string, ComponentType<any>> = {
-    'image': ImageComponent,
-    'game-menu': GameMenuComponent
+export interface IComponentRegistry {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerComponent(type: string, component: ComponentType<any>): void
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    getComponent(type: string): ComponentType<any> | undefined
+    clear(): void
 }
 
 const logName = 'ComponentRegistry'
 
-/**
- * Registers a new component under the specified type key.
- *
- * @param type - Unique string used to reference the component.
- * @param component - React component associated with the given type.
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const registerComponent = (type: string, component: ComponentType<any>): void => {
-    if (Object.prototype.hasOwnProperty.call(componentRegistry, type)) {
-        logWarning(logName, 'Component already registered under key {0}', type)
-        return
+export const componentRegistryToken = token<IComponentRegistry>(logName)
+export const componentRegistryDependencies: Token<unknown>[] = []
+
+export class ComponentRegistry implements IComponentRegistry {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    private readonly registry = new Map<string, ComponentType<any>>()
+
+    constructor() {
+        this.registerComponent('image', ImageComponent)
+        this.registerComponent('game-menu', GameMenuComponent)
     }
-    componentRegistry[type] = component
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    public registerComponent(type: string, component: ComponentType<any>): void {
+        if (this.registry.has(type)) {
+            logWarning(logName, 'Component already registered under key {0}', type)
+            return
+        }
+        this.registry.set(type, component)
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    public getComponent(type: string): ComponentType<any> | undefined {
+        return this.registry.get(type)
+    }
+
+    public clear(): void {
+        this.registry.clear()
+    }
 }
 

--- a/tests/engine/actionHandlerRegistry.test.ts
+++ b/tests/engine/actionHandlerRegistry.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest'
-import { ActionHandlerRegistry, actionHandlerRegistryToken, IActionHandler, IActionHandlerRegistry } from '@registries/actionHandlerRegistry'
+import { ActionHandlerRegistry, actionHandlerRegistryToken, IActionHandler, IActionHandlerRegistry, actionHandlerRegistryDependencies } from '@registries/actionHandlerRegistry'
 import { token } from '@ioc/token'
 import { Container } from '@ioc/container'
 import { IServiceProvider, ServiceProvider, serviceProviderToken } from '@providers/serviceProvider'
@@ -20,7 +20,7 @@ describe('ActionHandlerRegistry', () => {
     beforeEach(() => {
         container = new Container()
         container.register<IServiceProvider>({ token: serviceProviderToken, useFactory: c => new ServiceProvider(c) })
-        container.register<IActionHandlerRegistry>({ token: actionHandlerRegistryToken, useClass: ActionHandlerRegistry })
+        container.register<IActionHandlerRegistry>({ token: actionHandlerRegistryToken, useClass: ActionHandlerRegistry, deps: actionHandlerRegistryDependencies })
         registry = container.resolve(actionHandlerRegistryToken)
         registry.clear()
     })

--- a/tests/engine/componentRegistry.test.ts
+++ b/tests/engine/componentRegistry.test.ts
@@ -1,22 +1,36 @@
-import { describe, it, expect, vi } from 'vitest'
-import { registerComponent, componentRegistry } from '../../engine/registries/componentRegistry'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { ComponentRegistry, componentRegistryToken, IComponentRegistry } from '@registries/componentRegistry'
 import * as log from '../../utils/logMessage'
+import { Container } from '@ioc/container'
 
-describe('componentRegistry', () => {
+describe('ComponentRegistry', () => {
+    let registry: IComponentRegistry
+    let container: Container
+
+    beforeEach(() => {
+        container = new Container()
+        container.register<IComponentRegistry>({ token: componentRegistryToken, useClass: ComponentRegistry })
+        registry = container.resolve(componentRegistryToken)
+        registry.clear()
+    })
+
     it('logs a warning when registering a duplicate component and does not override it', () => {
         const key = 'test-component'
         const original = () => null
         const duplicate = () => null
         const warningSpy = vi.spyOn(log, 'logWarning')
 
-        registerComponent(key, original)
-        registerComponent(key, duplicate)
+        registry.registerComponent(key, original)
+        registry.registerComponent(key, duplicate)
 
         expect(warningSpy).toHaveBeenCalledTimes(1)
-        expect(componentRegistry[key]).toBe(original)
+        expect(registry.getComponent(key)).toBe(original)
 
         warningSpy.mockRestore()
-        delete componentRegistry[key]
+    })
+
+    it('returns undefined when no component registered for type', () => {
+        expect(registry.getComponent('missing')).toBeUndefined()
     })
 })
 


### PR DESCRIPTION
## Summary
- replace object-based component registry with class and DI token
- use registry via `useService` in component renderer
- wire `ComponentRegistry` into container builder and update tests

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_689ddcdcdcd48332b755936a73a02a84