### PR TITLE
docs: clarify MessageQueue handler processing

### DIFF
--- a/utils/messageQueue.ts
+++ b/utils/messageQueue.ts
@@ -63,7 +63,9 @@ export class MessageQueue implements IMessageQueue {
     }
 
     /**
-     * Set the handler responsible for processing messages.
+     * Set the handler responsible for processing messages. This immediately
+     * triggers {@link emptyQueue} after assignment so any queued messages are
+     * processed right away.
      * @param handler - Function invoked for each message.
      */
     public setHandler(handler: (message: Message) => void | Promise<void>): void {


### PR DESCRIPTION
## Summary
- document that `MessageQueue.setHandler` drains queued messages immediately

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_689de27e437483328703a92e5699b3bb