### PR TITLE
Clarify container builder comment

### DIFF
--- a/engine/builders/containerBuilder.ts
+++ b/engine/builders/containerBuilder.ts
@@ -61,7 +61,7 @@ export class ContainerBuilder implements IContainerBuilder {
         this.registerRegistries(result)
         this.registerManagers(result)
         this.registerActions(result)
-        // Register other dependencies as needed
+        // Additional service registrations go here
         return result
     }
 

--- a/tests/engine/pageManager.test.ts
+++ b/tests/engine/pageManager.test.ts
@@ -55,6 +55,7 @@ describe('PageManager', () => {
     const provider = {} as IGameDataProvider
     const loader = {} as IPageLoader
     const manager = new PageManager(provider, loader, bus)
+    manager.initialize()
     const spy = vi.spyOn(manager, 'setActivePage').mockResolvedValue(undefined)
 
     bus.postMessage({ message: SWITCH_PAGE, payload: 'home' })


### PR DESCRIPTION
## Summary
- Clarify container builder comment about where to add extra service registrations
- Initialize PageManager before asserting switch-page behavior in tests

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_689e043671408332b4f4aaeeae056138