### PR TITLE
Add default fatalError handling to mappers

### DIFF
--- a/engine/loader/mappers/condition.ts
+++ b/engine/loader/mappers/condition.ts
@@ -1,5 +1,8 @@
 import type { Condition as ConditionData } from '@loader/data/condition'
 import { type Condition } from '@loader/schema/condition'
+import { fatalError } from '@utils/logMessage'
+
+const logName = 'mapCondition'
 
 export function mapCondition(condition: Condition): ConditionData {
     switch(condition.type){
@@ -8,5 +11,8 @@ export function mapCondition(condition: Condition): ConditionData {
                 type: 'script',
                 script: condition.script
             }
+        default:
+            // Guard against unrecognized condition schema types
+            fatalError(logName, 'Unsupported condition type: {0}', (condition as { type: string }).type)
     }
 }

--- a/engine/loader/mappers/map.ts
+++ b/engine/loader/mappers/map.ts
@@ -1,6 +1,9 @@
 import type { GameMap as GameMapData, MapTile as MapTileData } from '@loader/data/map'
 import { type GameMap, type MapTile } from '@loader/schema/map'
+import { fatalError } from '@utils/logMessage'
 import { mapAction } from './action'
+
+const logName = 'mapGameMap'
 
 
 export function mapGameMap(gameMap: GameMap): GameMapData {
@@ -15,6 +18,9 @@ export function mapGameMap(gameMap: GameMap): GameMapData {
                 tiles: mapMapTiles(gameMap.tiles),
                 map: mapMap(gameMap.map)
             }
+        default:
+            // Guard against unrecognized map schema types
+            fatalError(logName, 'Unsupported map type: {0}', (gameMap as { type: string }).type)
     }
 }
 

--- a/engine/loader/mappers/page.ts
+++ b/engine/loader/mappers/page.ts
@@ -6,6 +6,10 @@ import { type Component } from '@loader/schema/component'
 import { type Button } from '@loader/schema/button'
 import { mapAction } from './action'
 import { mapInputs } from './input'
+import { fatalError } from '@utils/logMessage'
+
+const logScreen = 'mapScreen'
+const logComponent = 'mapComponent'
 
 export function mapPage(basePath: string,page: Page): PageData {
     return {
@@ -24,6 +28,9 @@ export function mapScreen(basePath: string, screen: Screen): ScreenData {
                 height: screen.height,
                 components: mapGridScreenComponents(basePath, screen.components)
             }
+        default:
+            // Guard against unrecognized screen schema types
+            fatalError(logScreen, 'Unsupported screen type: {0}', (screen as { type: string }).type)
     }
 }
 
@@ -90,6 +97,9 @@ export function mapComponent(basePath: string, component: Component): ComponentD
                 type: 'output-log',
                 logSize: component.logSize
             }
+        default:
+            // Guard against unrecognized component schema types
+            fatalError(logComponent, 'Unsupported component type: {0}', (component as { type: string }).type)
     }
 }
 


### PR DESCRIPTION
## Summary
- ensure condition mapper fails fast on unsupported types
- guard against unknown map schema types in map mapper
- prevent unrecognized screen and component types with fatal errors

## Testing
- `npm run build`
- `npm run lint`
- `npm run test` *(fails: PageManager > responds to SWITCH_PAGE messages and cleans up listeners)*

------
https://chatgpt.com/codex/tasks/task_e_689e04404da8833298558d4f19291b52