### PR TITLE
docs: document actions and game engine with JSDoc

### DIFF
--- a/engine/actions/actionExecuter.ts
+++ b/engine/actions/actionExecuter.ts
@@ -4,16 +4,45 @@ import { ActionHandlerRegistry, actionHandlerRegistryToken } from '@registries/a
 import { fatalError } from '@utils/logMessage'
 import { Message } from '@utils/types'
 
+/**
+ * Executes actions using registered action handlers.
+ */
 export interface IActionExecuter {
+    /**
+     * Executes the provided action by resolving and invoking its handler.
+     *
+     * @param action - The action to execute.
+     * @param message - Optional message that triggered the action.
+     * @param data - Additional data forwarded to the handler.
+     * @throws {@link fatalError} if no handler is registered for the action type.
+     */
     execute<T extends BaseAction = Action>(action: T, message?: Message, data?: unknown): void
 }
 
 const logName = 'ActionExecuter'
 export const actionExecuterToken = token<IActionExecuter>(logName)
 export const actionExecuterDependencies: Token<unknown>[] = [actionHandlerRegistryToken]
+
+/**
+ * Default implementation of {@link IActionExecuter} that delegates work to
+ * action handlers resolved from a registry.
+ */
 export class ActionExecuter implements IActionExecuter {
+    /**
+     * Creates a new {@link ActionExecuter}.
+     *
+     * @param actionHandlerRegistry - Registry used to look up action handlers.
+     */
     constructor(private actionHandlerRegistry: ActionHandlerRegistry){}
 
+    /**
+     * Executes the given action by invoking its associated handler.
+     *
+     * @param action - Action instance to execute.
+     * @param message - Optional message that led to the action.
+     * @param data - Supplementary data passed to the handler.
+     * @throws {@link fatalError} if no handler exists for the action type.
+     */
     public execute<T extends BaseAction = Action>(action: T, message?: Message, data?: unknown): void {
         const actionHandler = this.actionHandlerRegistry.getActionHandler(action.type)
         if (!actionHandler) fatalError(logName, 'No action handler found for type {0}', action.type)

--- a/engine/actions/postMessageAction.ts
+++ b/engine/actions/postMessageAction.ts
@@ -4,16 +4,36 @@ import { IMessageBus, messageBusToken } from '@utils/messageBus'
 import { Message } from '@utils/types'
 import { PostMessageAction as PostMessageActionData } from '@loader/data/action'
 
+/**
+ * Contract for handlers that post a message to the message bus.
+ */
 export type IPostMessageAction = IActionHandler<PostMessageActionData>
 
 const logName = 'PostMessageAction'
 export const postMessageActionToken = token<IPostMessageAction>(logName)
 export const PostMessageActionDependencies: Token<unknown>[] = [messageBusToken]
+
+/**
+ * {@link IActionHandler} implementation that forwards actions to the
+ * {@link IMessageBus}.
+ */
 export class PostMessageAction implements IPostMessageAction {
     readonly type = 'post-message' as const
 
+    /**
+     * Creates a new {@link PostMessageAction}.
+     *
+     * @param messageBus - Bus used to dispatch the message.
+     */
     constructor(private messageBus: IMessageBus){}
 
+    /**
+     * Posts the specified message through the {@link IMessageBus}.
+     *
+     * @param action - Contains the message and payload to dispatch.
+     * @param _message - Optional incoming message; ignored.
+     * @param _data - Optional auxiliary data; ignored.
+     */
     public handle(action: PostMessageActionData, _message?: Message, _data?: unknown): void {
         void _message
         void _data

--- a/engine/engine/gameEngine.ts
+++ b/engine/engine/gameEngine.ts
@@ -3,19 +3,42 @@ import { engineInitializerToken, IEngineInitializer } from './engineInitializer'
 import { logDebug } from '@utils/logMessage'
 
 
+/**
+ * Defines the contract for the central game engine.
+ */
 export interface IGameEngine {
+    /**
+     * Starts the game engine by initializing required subsystems.
+     *
+     * @returns A promise that resolves once initialization is complete.
+     */
     start(): Promise<void>
 }
 
 const logName: string = 'GameEngine'
 export const gameEngineToken = token<IGameEngine>(logName)
 export const gameEngineDependencies: Token<unknown>[] = [engineInitializerToken]
+
+/**
+ * Concrete implementation of {@link IGameEngine} responsible for bootstrapping
+ * the game.
+ */
 export class GameEngine implements IGameEngine {
+    /**
+     * Creates a new {@link GameEngine}.
+     *
+     * @param engineInitializer - Performs game initialization routines.
+     */
     constructor(
         private engineInitializer: IEngineInitializer
     ) {
     }
 
+    /**
+     * Boots the game engine by delegating to the {@link IEngineInitializer}.
+     *
+     * @returns A promise that resolves when the engine has fully started.
+     */
     async start(): Promise<void> {
         logDebug(logName, 'Starting game engine...')
         await this.engineInitializer.initialize()


### PR DESCRIPTION
## Summary
- document `ActionExecuter` interface and class with execution error details
- add JSDoc for `PostMessageAction` handler and methods
- describe `GameEngine` initialization and startup contracts

## Testing
- `npm run build`
- `npm run lint`
- `npm run test` *(fails: PageManager > responds to SWITCH_PAGE messages and cleans up listeners)*

------
https://chatgpt.com/codex/tasks/task_e_689e04469d688332bf736ce6ff7b787b