### PR TITLE
docs: add component JSDoc

### DIFF
--- a/engine/app/app.tsx
+++ b/engine/app/app.tsx
@@ -4,6 +4,10 @@ import { Page } from './controls/page'
 import { useService } from './iocProvider'
 import { PAGE_SWITCHED } from '@messages/system'
 
+/**
+ * Top-level application component.
+ * Subscribes to PAGE_SWITCHED messages and renders the current page.
+ */
 export const App: React.FC = (): React.JSX.Element => {
   const messageBus = useService<IMessageBus>(messageBusToken)
   const [pageId, setPageId] = useState<string | null>(null)

--- a/engine/app/controls/component/component.tsx
+++ b/engine/app/controls/component/component.tsx
@@ -7,6 +7,11 @@ interface ComponentProps {
     component: ComponentData
 }
 
+/**
+ * Fallback renderer for unsupported component types.
+ * Logs a warning when an unknown component is encountered.
+ * @param component - Definition of the unknown component.
+ */
 const DefaultComponent: React.FC<ComponentProps> = ({ component }): React.JSX.Element => {
     logWarning('Component', 'Unknown component type: {0}', component.type)
     return (
@@ -14,6 +19,10 @@ const DefaultComponent: React.FC<ComponentProps> = ({ component }): React.JSX.El
     )
 }
 
+/**
+ * Resolves and renders a component using the registry.
+ * @param component - Component definition to render.
+ */
 export const Component: React.FC<ComponentProps> = ({ component }): React.JSX.Element => {
     const registry = useService<IComponentRegistry>(componentRegistryToken)
     const ComponentImpl = registry.getComponent(component.type) ?? DefaultComponent

--- a/engine/app/controls/component/gameMenuComponent.tsx
+++ b/engine/app/controls/component/gameMenuComponent.tsx
@@ -8,6 +8,11 @@ interface GameMenuComponentProps {
     component: GameMenuComponentData
 }
 
+/**
+ * Renders a game menu with buttons.
+ * Executes each button's action when clicked.
+ * @param component - Game menu definition.
+ */
 export const GameMenuComponent: React.FC<GameMenuComponentProps> = ({ component }): React.JSX.Element => {
     const translationService = useService<ITranslationService>(translationServiceToken)
     const actionExecuter = useService<IActionExecuter>(actionExecuterToken)

--- a/engine/app/controls/component/imageComponent.tsx
+++ b/engine/app/controls/component/imageComponent.tsx
@@ -5,6 +5,10 @@ interface ImageComponentProps {
     component: ImageComponentData
 }
 
+/**
+ * Displays an image using CSS custom properties.
+ * @param component - Image component definition.
+ */
 export const ImageComponent: React.FC<ImageComponentProps> = ({ component }): React.JSX.Element => {
     const style: CSSCustomProperties = {
         '--ge-image-path': `url("${component.image}")`,

--- a/engine/app/controls/page.tsx
+++ b/engine/app/controls/page.tsx
@@ -6,6 +6,10 @@ interface PageProps {
     pageId: string
 }
 
+/**
+ * Displays the screen for a given page.
+ * @param pageId - Identifier of the page to render.
+ */
 export const Page: React.FC<PageProps> = ({ pageId }): React.JSX.Element => {
     const gameDataProvider = useService<IGameDataProvider>(gameDataProviderToken)
     if (gameDataProvider.Context.currentPageId !== pageId || !gameDataProvider.Game.loadedPages[pageId]) return (<></>)

--- a/engine/app/controls/screen/grid.tsx
+++ b/engine/app/controls/screen/grid.tsx
@@ -8,6 +8,11 @@ interface GridProps {
     screen: GridScreen
 }
 
+/**
+ * Renders a grid layout of components.
+ * Evaluates conditions using the condition resolver registry.
+ * @param screen - Grid screen data to render.
+ */
 export const Grid: React.FC<GridProps> = ({ screen }): React.JSX.Element => {
     const style: CSSCustomProperties = {
         '--ge-grid-width': screen.width.toString(),

--- a/engine/app/controls/screen/screen.tsx
+++ b/engine/app/controls/screen/screen.tsx
@@ -8,6 +8,11 @@ interface ScreenProps {
 
 const logName = 'Screen'
 
+/**
+ * Selects a renderer for the provided screen data.
+ * Logs a warning for unsupported screen types.
+ * @param screen - Screen data to render.
+ */
 export const Screen: React.FC<ScreenProps> = ({ screen }): React.JSX.Element | null => {
     switch (screen.type) {
         case 'grid':

--- a/tests/engine/pageManager.test.ts
+++ b/tests/engine/pageManager.test.ts
@@ -56,7 +56,7 @@ describe('PageManager', () => {
     const loader = {} as IPageLoader
     const manager = new PageManager(provider, loader, bus)
     const spy = vi.spyOn(manager, 'setActivePage').mockResolvedValue(undefined)
-
+    manager.initialize()
     bus.postMessage({ message: SWITCH_PAGE, payload: 'home' })
     await Promise.resolve()
     expect(spy).toHaveBeenCalledWith('home')


### PR DESCRIPTION
## Summary
- document core app and control components with JSDoc
- initialize PageManager in test to ensure listener registration

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_689e044acd408332a38331e8a8c98aa6