### PR TITLE
docs: document container methods

### DIFF
--- a/engine/ioc/container.ts
+++ b/engine/ioc/container.ts
@@ -16,6 +16,14 @@ export class Container {
 
   constructor(parent?: Container) { this.parent = parent }
 
+  /**
+   * Registers a provider for the given token in the current container.
+   *
+   * @param provider - Provider configuration describing how the token should be
+   *   resolved.
+   * @returns The container instance to allow method chaining.
+   * @throws Logs and terminates if a provider for the token already exists.
+   */
   register<T>(provider: Provider<T>): this {
     if (this.providers.has(provider.token)) {
       fatalError(logName, 'Provider for {0} already registered', describeToken(provider.token))
@@ -24,17 +32,54 @@ export class Container {
     return this
   }
 
+  /**
+   * Registers an array of providers.
+   *
+   * Each provider is passed to {@link register}. Registration halts on the
+   * first duplicate provider because {@link register} throws via `fatalError`.
+   *
+   * @param providers - Providers to be added to the container.
+   * @returns The container instance for chaining.
+   */
   registerAll(providers: Provider<unknown>[]): this {
     providers.forEach(p => this.register(p))
     return this
   }
 
+  /**
+   * Determines whether a provider for the specified token exists either in
+   * this container or any of its ancestors.
+   *
+   * @param t - Token to look up.
+   * @returns `true` if a provider is registered; otherwise `false`.
+   */
   has<T>(t: Token<T>): boolean {
     return this.providers.has(t) || !!this.parent?.has(t)
   }
 
+  /**
+   * Creates a child container that inherits all providers from the current
+   * container but allows overriding or extending them.
+   *
+   * @returns A newly constructed child container.
+   */
   createChild(): Container { return new Container(this) }
 
+  /**
+   * Resolves an instance for the given token.
+   *
+   * - Detects circular dependencies and aborts with a descriptive error when
+   *   encountered.
+   * - Providers marked with `scope: 'singleton'` are cached so subsequent calls
+   *   return the same instance. If the provider uses `useValue` with a function
+   *   value, the value is returned directly on each call without caching,
+   *   allowing multiple consumers to receive the raw function.
+   *
+   * @param t - Token identifying the provider.
+   * @returns The resolved instance.
+   * @throws Logs and terminates if no provider exists or a circular dependency
+   *   is detected.
+   */
   resolve<T>(t: Token<T>): T {
     if (this.singletons.has(t)) return this.singletons.get(t) as T
 
@@ -62,6 +107,21 @@ export class Container {
     return (this.providers.get(t) ?? this.parent?.getProvider(t)) as Provider<T> | undefined
   }
 
+  /**
+   * Instantiates a provider.
+   *
+   * Handles all supported provider configurations:
+   * - `useValue`: returns the supplied value as-is without invoking it.
+   * - `useClass`: resolves each dependency and constructs the class.
+   * - `useFactory`: invokes the factory with the current container.
+   *
+   * This method does not perform caching; caller ({@link resolve}) is
+   * responsible for handling singleton scope.
+   *
+   * @param p - Provider description.
+   * @returns The instantiated value.
+   * @throws Logs and terminates if the provider configuration is invalid.
+   */
   private instantiate<T>(p: Provider<T>): T {
     if ('useValue' in p) return p.useValue
     if ('useClass' in p) {
@@ -69,7 +129,7 @@ export class Container {
       return new p.useClass(...deps)
     }
     if ('useFactory' in p) return p.useFactory(this)
-    
+
     fatalError(logName, 'Invalid provider for {0}', describeToken((p as Provider<T>).token))
   }
 }

--- a/tests/engine/pageManager.test.ts
+++ b/tests/engine/pageManager.test.ts
@@ -57,6 +57,7 @@ describe('PageManager', () => {
     const manager = new PageManager(provider, loader, bus)
     const spy = vi.spyOn(manager, 'setActivePage').mockResolvedValue(undefined)
 
+    manager.initialize()
     bus.postMessage({ message: SWITCH_PAGE, payload: 'home' })
     await Promise.resolve()
     expect(spy).toHaveBeenCalledWith('home')


### PR DESCRIPTION
## Summary
- document IoC container methods with detailed JSDoc
- initialize PageManager in tests before posting switch messages

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_689e044efc688332b5d527a08b1e53d6