### PR TITLE
fix: prevent duplicate page manager listeners

### DIFF
--- a/engine/managers/pageManager.ts
+++ b/engine/managers/pageManager.ts
@@ -55,6 +55,8 @@ export class PageManager implements IPageManager {
     }
 
     initialize(): void {
+        // Ensure we don't register multiple listeners if initialize is called more than once
+        this.cleanupFn?.()
         this.cleanupFn = this.messageBus.registerMessageListener(
             SWITCH_PAGE,
             async message => {


### PR DESCRIPTION
## Summary
- avoid registering multiple SWITCH_PAGE listeners if PageManager.initialize is called repeatedly

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e0d51de748332a87561cac7eadcee