### PR TITLE
chore: remove redundant unregister comment

### DIFF
--- a/utils/messageBus.ts
+++ b/utils/messageBus.ts
@@ -136,7 +136,6 @@ export class MessageBus implements IMessageBus {
         }
         this.listeners.get(message)!.push(listener)
 
-        // return the unregister function
         return () => {
             const arr = this.listeners.get(message)
             if (arr) {


### PR DESCRIPTION
## Summary
- remove inline unregister comment in messageBus listener registration

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_689e2ccfd9d08332baf0d29cfbfa1955