### PR TITLE
Fix async tile set loading in MapManager

### DIFF
--- a/engine/managers/mapManager.ts
+++ b/engine/managers/mapManager.ts
@@ -65,15 +65,17 @@ export class MapManager implements IMapManager {
         })
     }
 
-    public async ensureTileSets(tileSetIds: string[]){
-        tileSetIds.forEach(tileSetId => {
-            const path = this.gameDataProvider.Game.game.tiles[tileSetId]
-            if (!path) fatalError(logName, 'Tile set not found for id {0}', tileSetId)
-    
-            if (this.gameDataProvider.Game.loadedTileSets[tileSetId] === undefined) {
-                const tileSet = await this.tileSetLoader.loadTileSet(path)
-                this.gameDataProvider.Game.loadedTileSets[tileSetId] = tileSet
-            }
-        })
+    public async ensureTileSets(tileSetIds: string[]): Promise<void> {
+        await Promise.all(
+            tileSetIds.map(async tileSetId => {
+                const path = this.gameDataProvider.Game.game.tiles[tileSetId]
+                if (!path) fatalError(logName, 'Tile set not found for id {0}', tileSetId)
+
+                if (this.gameDataProvider.Game.loadedTileSets[tileSetId] === undefined) {
+                    const tileSet = await this.tileSetLoader.loadTileSet(path)
+                    this.gameDataProvider.Game.loadedTileSets[tileSetId] = tileSet
+                }
+            })
+        )
     }
 }

--- a/tests/engine/mapManager.test.ts
+++ b/tests/engine/mapManager.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from 'vitest'
+import { MapManager } from '../../engine/managers/mapManager'
+import type { IGameMapLoader } from '../../engine/loader/gameMapLoader'
+import type { IMessageBus } from '../../utils/messageBus'
+import type { IGameDataProvider, GameData, GameContext } from '../../engine/providers/gameDataProvider'
+import type { ITileSetLoader } from '../../engine/loader/tileSetLoader'
+
+function createManager(gameData: GameData, loadTileSet: ReturnType<typeof vi.fn>) {
+    const provider = {
+        get Game() { return gameData },
+        get Context() { return {} as GameContext },
+        initialize: vi.fn()
+    } as unknown as IGameDataProvider
+    const tileSetLoader = { loadTileSet } as unknown as ITileSetLoader
+    const mapLoader = {} as IGameMapLoader
+    const bus = {} as IMessageBus
+    return new MapManager(mapLoader, bus, provider, tileSetLoader)
+}
+
+describe('MapManager.ensureTileSets', () => {
+    it('loads tile sets that are not yet loaded', async () => {
+        const gameData = {
+            game: { tiles: { ts1: 'ts1.json' } },
+            loadedTileSets: {}
+        } as unknown as GameData
+        const loadTileSet = vi.fn().mockResolvedValue({ id: 'ts1' })
+        const manager = createManager(gameData, loadTileSet)
+
+        await manager.ensureTileSets(['ts1'])
+
+        expect(loadTileSet).toHaveBeenCalledWith('ts1.json')
+        expect(gameData.loadedTileSets['ts1']).toEqual({ id: 'ts1' })
+    })
+
+    it('does not reload tile sets that are already loaded', async () => {
+        const gameData = {
+            game: { tiles: { ts1: 'ts1.json' } },
+            loadedTileSets: { ts1: { id: 'ts1' } }
+        } as unknown as GameData
+        const loadTileSet = vi.fn().mockResolvedValue({ id: 'ts1-new' })
+        const manager = createManager(gameData, loadTileSet)
+
+        await manager.ensureTileSets(['ts1'])
+
+        expect(loadTileSet).not.toHaveBeenCalled()
+        expect(gameData.loadedTileSets['ts1']).toEqual({ id: 'ts1' })
+    })
+})


### PR DESCRIPTION
## Summary
- fix asynchronous tile set loading in MapManager by replacing `forEach` with `Promise.all`
- add unit tests for MapManager.ensureTileSets to cover loading and caching behavior

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e44396a0483328299c53ee0e11444