### PR TITLE
test: add ActionExecuter tests

### DIFF
--- a/tests/engine/actionExecuter.test.ts
+++ b/tests/engine/actionExecuter.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { ActionExecuter } from '@actions/actionExecuter'
+import type { BaseAction } from '@loader/data/action'
+import type { ActionHandlerRegistry } from '@registries/actionHandlerRegistry'
+import * as log from '../../utils/logMessage'
+
+const KNOWN_TYPE = 'known-action'
+
+describe('ActionExecuter', () => {
+    let handler: { handle: ReturnType<typeof vi.fn> }
+    let registry: ActionHandlerRegistry
+    let executer: ActionExecuter
+
+    beforeEach(() => {
+        handler = { handle: vi.fn() }
+        registry = {
+            getActionHandler: vi.fn((type: string) => (type === KNOWN_TYPE ? handler : undefined))
+        } as unknown as ActionHandlerRegistry
+        executer = new ActionExecuter(registry)
+    })
+
+    it('invokes handler when registered', () => {
+        const action = { type: KNOWN_TYPE } as BaseAction
+        executer.execute(action)
+        expect(handler.handle).toHaveBeenCalledWith(action, undefined, undefined)
+    })
+
+    it('triggers fatalError when handler missing', () => {
+        const action = { type: 'missing-action' } as BaseAction
+        const fatalErrorSpy = vi.spyOn(log, 'fatalError')
+        expect(() => executer.execute(action)).toThrow()
+        expect(fatalErrorSpy).toHaveBeenCalledWith('ActionExecuter', 'No action handler found for type {0}', 'missing-action')
+        fatalErrorSpy.mockRestore()
+    })
+})
+


### PR DESCRIPTION
## Summary
- add unit tests for ActionExecuter
- verify handlers are invoked for registered actions
- ensure fatalError is called when no handler is found

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e4568dddc8332894eadafebbcc4dc