### PR TITLE
Add PostMessageAction unit test

### DIFF
--- a/tests/engine/postMessageAction.test.ts
+++ b/tests/engine/postMessageAction.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect, vi } from 'vitest'
+import { PostMessageAction } from '@actions/postMessageAction'
+import type { IMessageBus } from '@utils/messageBus'
+import type { PostMessageAction as PostMessageActionData } from '@loader/data/action'
+
+describe('PostMessageAction', () => {
+  it('posts the specified message to the message bus', () => {
+    const postMessage = vi.fn()
+    const messageBus = { postMessage } as unknown as IMessageBus
+    const action = new PostMessageAction(messageBus)
+    const data: PostMessageActionData = {
+      type: 'post-message',
+      message: 'test-message',
+      payload: { foo: 'bar' }
+    }
+
+    action.handle(data)
+
+    expect(postMessage).toHaveBeenCalledWith({ message: 'test-message', payload: { foo: 'bar' } })
+  })
+})


### PR DESCRIPTION
## Summary
- add unit test for PostMessageAction posting messages to message bus

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_689e456987688332875b465d2c47e673