### PR TITLE
Add loader tests and fix handler reduction

### DIFF
--- a/engine/loader/actionHandlersLoader.ts
+++ b/engine/loader/actionHandlersLoader.ts
@@ -25,8 +25,8 @@ export class ActionHandlersLoader implements IActionHandlersLoader {
         const schemas = await Promise.all(
             paths.map(path => loadJsonResource<Handlers>(`${this.basePathProvider.dataPath}/${path}`, handlersSchema))
         )
-        
-        const handlers = schemas.reduce((acc, schema) => [...acc, ...mapHandlers(schema)])
-        return handlers as HandlersData
+
+        const handlers = schemas.reduce<HandlersData>((acc, schema) => [...acc, ...mapHandlers(schema)], [])
+        return handlers
     }
 }

--- a/tests/engine/actionHandlersLoader.test.ts
+++ b/tests/engine/actionHandlersLoader.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach, Mock } from 'vitest'
+
+vi.mock('@utils/loadJsonResource', () => ({ loadJsonResource: vi.fn() }))
+vi.mock('@loader/mappers/handler', () => ({ mapHandlers: vi.fn() }))
+
+import { loadJsonResource } from '@utils/loadJsonResource'
+import { mapHandlers } from '@loader/mappers/handler'
+import { ActionHandlersLoader } from '@loader/actionHandlersLoader'
+
+const basePathProvider = { dataPath: '/base' }
+
+describe('ActionHandlersLoader', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('loads and maps action handlers using dataPath', async () => {
+    const schema1: unknown = [{ s: 1 }]
+    const schema2: unknown = [{ s: 2 }]
+    ;(loadJsonResource as unknown as Mock)
+      .mockResolvedValueOnce(schema1)
+      .mockResolvedValueOnce(schema2)
+    ;(mapHandlers as unknown as Mock)
+      .mockReturnValueOnce([{ id: 1 }])
+      .mockReturnValueOnce([{ id: 2 }])
+
+    const loader = new ActionHandlersLoader(basePathProvider)
+    const result = await loader.loadActions(['a.json', 'b.json'])
+
+    expect(loadJsonResource).toHaveBeenNthCalledWith(1, '/base/a.json', expect.anything())
+    expect(loadJsonResource).toHaveBeenNthCalledWith(2, '/base/b.json', expect.anything())
+    expect(mapHandlers).toHaveBeenNthCalledWith(1, schema1)
+    expect(mapHandlers).toHaveBeenNthCalledWith(2, schema2)
+    expect(result).toEqual([{ id: 1 }, { id: 2 }])
+  })
+
+  it('throws when no handler paths provided', async () => {
+    const loader = new ActionHandlersLoader(basePathProvider)
+    await expect(loader.loadActions([])).rejects.toThrow('No action handlers paths provided')
+  })
+})

--- a/tests/engine/gameLoader.test.ts
+++ b/tests/engine/gameLoader.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi, beforeEach, Mock } from 'vitest'
+
+vi.mock('@utils/loadJsonResource', () => ({ loadJsonResource: vi.fn() }))
+vi.mock('@loader/mappers/game', () => ({ mapGame: vi.fn() }))
+
+import { loadJsonResource } from '@utils/loadJsonResource'
+import { mapGame } from '@loader/mappers/game'
+import { GameLoader } from '@loader/gameLoader'
+
+const basePathProvider = { dataPath: '/base' }
+
+describe('GameLoader', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('loads game using dataPath and maps it', async () => {
+    const schema: unknown = { raw: true }
+    ;(loadJsonResource as unknown as Mock).mockResolvedValue(schema)
+    const mapped = { mapped: true }
+    ;(mapGame as unknown as Mock).mockReturnValue(mapped)
+
+    const loader = new GameLoader(basePathProvider)
+    const result = await loader.loadGame()
+
+    expect(loadJsonResource).toHaveBeenCalledWith('/base/index.json', expect.anything())
+    expect(mapGame).toHaveBeenCalledWith(schema, '/base')
+    expect(result).toBe(mapped)
+  })
+})

--- a/tests/engine/languageLoader.test.ts
+++ b/tests/engine/languageLoader.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach, Mock } from 'vitest'
+
+vi.mock('@utils/loadJsonResource', () => ({ loadJsonResource: vi.fn() }))
+vi.mock('@loader/mappers/language', () => ({ mapLanguage: vi.fn() }))
+
+import { loadJsonResource } from '@utils/loadJsonResource'
+import { mapLanguage } from '@loader/mappers/language'
+import { LanguageLoader } from '@loader/languageLoader'
+
+const basePathProvider = { dataPath: '/base' }
+
+describe('LanguageLoader', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('loads and merges languages using dataPath', async () => {
+    const schema1: unknown = { s: 1 }
+    const schema2: unknown = { s: 2 }
+    ;(loadJsonResource as unknown as Mock)
+      .mockResolvedValueOnce(schema1)
+      .mockResolvedValueOnce(schema2)
+    ;(mapLanguage as unknown as Mock)
+      .mockReturnValueOnce({ id: 'en', translations: { a: '1' } })
+      .mockReturnValueOnce({ id: 'en', translations: { b: '2' } })
+
+    const loader = new LanguageLoader(basePathProvider)
+    const result = await loader.loadLanguage(['lang/en.json', 'lang/en-extra.json'])
+
+    expect(loadJsonResource).toHaveBeenNthCalledWith(1, '/base/lang/en.json', expect.anything())
+    expect(loadJsonResource).toHaveBeenNthCalledWith(2, '/base/lang/en-extra.json', expect.anything())
+    const mock = mapLanguage as unknown as Mock
+    expect(mock.mock.calls[0][0]).toBe(schema1)
+    expect(mock.mock.calls[1][0]).toBe(schema2)
+    expect(result).toEqual({ id: 'en', translations: { a: '1', b: '2' } })
+  })
+
+  it('throws when no language paths provided', async () => {
+    const loader = new LanguageLoader(basePathProvider)
+    await expect(loader.loadLanguage([])).rejects.toThrow('No language paths provided')
+  })
+
+  it('throws on mismatched language ids', async () => {
+    const schema1: unknown = { s: 1 }
+    const schema2: unknown = { s: 2 }
+    ;(loadJsonResource as unknown as Mock)
+      .mockResolvedValueOnce(schema1)
+      .mockResolvedValueOnce(schema2)
+    ;(mapLanguage as unknown as Mock)
+      .mockReturnValueOnce({ id: 'en', translations: {} })
+      .mockReturnValueOnce({ id: 'fr', translations: {} })
+
+    const loader = new LanguageLoader(basePathProvider)
+    await expect(loader.loadLanguage(['a.json', 'b.json'])).rejects.toThrow(/Language ID mismatch/)
+  })
+})

--- a/tests/engine/pageLoader.test.ts
+++ b/tests/engine/pageLoader.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi, beforeEach, Mock } from 'vitest'
+
+vi.mock('@utils/loadJsonResource', () => ({ loadJsonResource: vi.fn() }))
+vi.mock('@loader/mappers/page', () => ({ mapPage: vi.fn() }))
+
+import { loadJsonResource } from '@utils/loadJsonResource'
+import { mapPage } from '@loader/mappers/page'
+import { PageLoader } from '@loader/pageLoader'
+
+const basePathProvider = { dataPath: '/base' }
+
+describe('PageLoader', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('loads page using dataPath and maps it', async () => {
+    const schema: unknown = { id: 'page' }
+    ;(loadJsonResource as unknown as Mock).mockResolvedValue(schema)
+    const mapped = { id: 'page', content: [] }
+    ;(mapPage as unknown as Mock).mockReturnValue(mapped)
+
+    const loader = new PageLoader(basePathProvider)
+    const result = await loader.loadPage('pages/start.json')
+
+    expect(loadJsonResource).toHaveBeenCalledWith('/base/pages/start.json', expect.anything())
+    expect(mapPage).toHaveBeenCalledWith('/base', schema)
+    expect(result).toBe(mapped)
+  })
+})


### PR DESCRIPTION
## Summary
- add tests for game, page, language, and action handler loaders
- ensure action handler loader maps all handler files correctly

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e45711bb08332b80dd104c6ef1906