### PR TITLE
docs: add JSDoc for IoC provider and hook

### DIFF
--- a/engine/app/iocProvider.tsx
+++ b/engine/app/iocProvider.tsx
@@ -5,12 +5,30 @@ import { fatalError } from '@utils/logMessage'
 
 const logName = 'IocProvider'
 
+/**
+ * React context providing access to the application's IoC container.
+ */
 export const IocContext = createContext<Container | null>(null)
 
+/**
+ * Supplies a {@link Container} to descendant components through {@link IocContext}.
+ *
+ * @param props - Props including the IoC container and optional children.
+ * @param props.container - Container used to resolve services.
+ * @param props.children - Elements that will have access to the container.
+ * @returns The wrapped React elements.
+ */
 export const IocProvider = ({ container, children }: PropsWithChildren<{ container: Container }>) => {
   return <IocContext.Provider value={container}>{children}</IocContext.Provider>
 }
 
+/**
+ * Resolve a service instance for the provided token.
+ *
+ * @param t - Token identifying the desired service.
+ * @returns The resolved service instance.
+ * @throws via {@link fatalError} when `IocProvider` is missing from the tree.
+ */
 export const useService = <T,>(t: Token<T>): T => {
   const c = useContext(IocContext)
   if (!c) fatalError(logName, 'IocProvider is missing in the tree')


### PR DESCRIPTION
## Summary
- document `IocContext` with purpose of providing the IoC container
- add JSDoc for `IocProvider` including props and return details
- describe `useService` hook and its behavior when provider is missing

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_689e60a1f800833296094e6ced381d35