### PR TITLE
fix: correct position mapper spelling

### DIFF
--- a/engine/loader/mappers/map.ts
+++ b/engine/loader/mappers/map.ts
@@ -45,7 +45,13 @@ export function mapMap(map: string[]): string[][] {
     return map.map(row => row.split(','))
 }
 
-export function mapPostion(position: Position): PositionData {
+/**
+ * Converts a schema `Position` into its loader data representation.
+ *
+ * @param position - Position defined in the schema.
+ * @returns The mapped position for the data layer.
+ */
+export function mapPosition(position: Position): PositionData {
     return {
         x: position.x,
         y: position.y


### PR DESCRIPTION
## Summary
- rename `mapPostion` to `mapPosition`
- document position mapping

## Testing
- `npm run build` *(fails: Expected 9 arguments...)*
- `npm run lint`
- `npm run test` *(fails: 3 failed, 23 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689f3f0e4b248332b1baf9fe8c0e5a1c