### PR TITLE
refactor: add generic typing to component registry

### DIFF
--- a/engine/registries/componentRegistry.ts
+++ b/engine/registries/componentRegistry.ts
@@ -12,10 +12,8 @@ import { token, Token } from '@ioc/token'
 import { SquaresMapComponent } from '@app/controls/component/squaresMapComponent'
 
 export interface IComponentRegistry {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    registerComponent(type: string, component: ComponentType<any>): void
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    getComponent(type: string): ComponentType<any> | undefined
+    registerComponent<T = unknown>(type: string, component: ComponentType<T>): void
+    getComponent<T = unknown>(type: string): ComponentType<T> | undefined
     clear(): void
 }
 
@@ -25,8 +23,7 @@ export const componentRegistryToken = token<IComponentRegistry>(logName)
 export const componentRegistryDependencies: Token<unknown>[] = []
 
 export class ComponentRegistry implements IComponentRegistry {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    private readonly registry = new Map<string, ComponentType<any>>()
+    private readonly registry = new Map<string, ComponentType<unknown>>()
 
     constructor() {
         this.registerComponent('image', ImageComponent)
@@ -34,18 +31,16 @@ export class ComponentRegistry implements IComponentRegistry {
         this.registerComponent('squares-map', SquaresMapComponent)
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    public registerComponent(type: string, component: ComponentType<any>): void {
+    public registerComponent<T = unknown>(type: string, component: ComponentType<T>): void {
         if (this.registry.has(type)) {
             logWarning(logName, 'Component already registered under key {0}', type)
             return
         }
-        this.registry.set(type, component)
+        this.registry.set(type, component as ComponentType<unknown>)
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    public getComponent(type: string): ComponentType<any> | undefined {
-        return this.registry.get(type)
+    public getComponent<T = unknown>(type: string): ComponentType<T> | undefined {
+        return this.registry.get(type) as ComponentType<T> | undefined
     }
 
     public clear(): void {


### PR DESCRIPTION
## Summary
- refactor component registry to use generic typing instead of any
- remove redundant eslint-disable annotations

## Testing
- `npm run build` (fails: tests/engine/engineInitializer.test.ts expected 9 arguments but got 8; tests/engine/mapManager.test.ts element has implicit any, etc.)
- `npm run lint`
- `npm run test` (fails: EngineInitializer initializes engine and posts start messages; GameDataProvider initializes game and context; MapManager ensureTileSets loads tile sets that are not yet loaded; MapManager ensureTileSets does not reload tile sets that are already loaded)


------
https://chatgpt.com/codex/tasks/task_e_689f3f2067fc83329fe09352314f2465