### PR TITLE
docs: clarify container builder hook

### DIFF
--- a/engine/builders/containerBuilder.ts
+++ b/engine/builders/containerBuilder.ts
@@ -66,7 +66,7 @@ export class ContainerBuilder implements IContainerBuilder {
         this.registerRegistries(result)
         this.registerManagers(result)
         this.registerActions(result)
-        // Additional service registrations go here
+        // Hook for custom service registrations
         return result
     }
 


### PR DESCRIPTION
## Summary
- clarify hook comment for custom service registrations in container builder

## Testing
- `npm run lint`
- `npm run build` (fails: Expected 9 arguments but got 8)
- `npm test` (fails: 4 tests)


------
https://chatgpt.com/codex/tasks/task_e_689f3f30f7bc83328a17c91ac1d17e72