### PR TITLE
fix: update tests for map manager integration

### DIFF
--- a/tests/engine/engineInitializer.test.ts
+++ b/tests/engine/engineInitializer.test.ts
@@ -10,6 +10,7 @@ import type { IGameDataProvider } from '../../engine/providers/gameDataProvider'
 import type { IActionHandlerRegistry } from '../../engine/registries/actionHandlerRegistry'
 import type { IPageManager } from '../../engine/managers/pageManager'
 import type { IActionManager } from '../../engine/managers/actionManager'
+import type { IMapManager } from '../../engine/managers/mapManager'
 import type { Game } from '../../engine/loader/data/game'
 
 describe('EngineInitializer', () => {
@@ -38,6 +39,7 @@ describe('EngineInitializer', () => {
     const actionHandlerRegistry = { registerActionHandler: vi.fn() } as unknown as IActionHandlerRegistry
     const pageManager = { initialize: vi.fn() } as unknown as IPageManager
     const actionManager = { initialize: vi.fn() } as unknown as IActionManager
+    const mapManager = { initialize: vi.fn() } as unknown as IMapManager
 
     const initializer = new EngineInitializer(
       messageBus,
@@ -47,7 +49,8 @@ describe('EngineInitializer', () => {
       gameDataProvider,
       actionHandlerRegistry,
       pageManager,
-      actionManager
+      actionManager,
+      mapManager
     )
 
     await initializer.initialize()
@@ -56,6 +59,7 @@ describe('EngineInitializer', () => {
     expect(gameDataProvider.initialize).toHaveBeenCalledWith(game)
     expect(pageManager.initialize).toHaveBeenCalledTimes(1)
     expect(actionManager.initialize).toHaveBeenCalledTimes(1)
+    expect(mapManager.initialize).toHaveBeenCalledTimes(1)
     expect(languageManager.setLanguage).toHaveBeenCalledWith('en')
     expect(domManager.setTitle).toHaveBeenCalledWith('Test Game')
     expect(domManager.setCssFile).toHaveBeenCalledTimes(2)

--- a/tests/engine/gameDataProvider.test.ts
+++ b/tests/engine/gameDataProvider.test.ts
@@ -23,18 +23,18 @@ describe('GameDataProvider', () => {
     const provider = new GameDataProvider()
     provider.initialize(gameData)
 
-    expect(provider.Game).toEqual({
-      game: gameData,
-      loadedLanguages: {},
-      loadedPages: {},
-      loadedMaps: {},
-      loadedTileSets: {}
-    })
+    expect(provider.Game.game).toBe(gameData)
+    expect(provider.Game.loadedLanguages).toEqual({})
+    expect(provider.Game.loadedPages).toEqual({})
+    expect(provider.Game.loadedMaps).toEqual({})
+    expect(provider.Game.loadedTileSets).toEqual(new Set())
+    expect(provider.Game.loadedTiles).toEqual(new Map())
     expect(provider.Context).toEqual({
       language: 'en',
       startPage: 'start',
       currentPageId: null,
-      currentMapId: null
+      currentMapId: null,
+      player: { position: { x: 0, y: 0 } }
     })
   })
 

--- a/tests/engine/mapManager.test.ts
+++ b/tests/engine/mapManager.test.ts
@@ -21,28 +21,32 @@ describe('MapManager.ensureTileSets', () => {
     it('loads tile sets that are not yet loaded', async () => {
         const gameData = {
             game: { tiles: { ts1: 'ts1.json' } },
-            loadedTileSets: {}
+            loadedTileSets: new Set<string>(),
+            loadedTiles: new Map()
         } as unknown as GameData
-        const loadTileSet = vi.fn().mockResolvedValue({ id: 'ts1' })
+        const loadTileSet = vi.fn().mockResolvedValue({ id: 'ts1', tiles: [{ key: 'tile1' }] })
         const manager = createManager(gameData, loadTileSet)
 
         await manager.ensureTileSets(['ts1'])
 
         expect(loadTileSet).toHaveBeenCalledWith('ts1.json')
-        expect(gameData.loadedTileSets['ts1']).toEqual({ id: 'ts1' })
+        expect(gameData.loadedTileSets.has('ts1')).toBe(true)
+        expect(gameData.loadedTiles.get('tile1')).toEqual({ key: 'tile1' })
     })
 
     it('does not reload tile sets that are already loaded', async () => {
         const gameData = {
             game: { tiles: { ts1: 'ts1.json' } },
-            loadedTileSets: { ts1: { id: 'ts1' } }
+            loadedTileSets: new Set<string>(['ts1']),
+            loadedTiles: new Map([['tile1', { key: 'tile1' }]])
         } as unknown as GameData
-        const loadTileSet = vi.fn().mockResolvedValue({ id: 'ts1-new' })
+        const loadTileSet = vi.fn().mockResolvedValue({ id: 'ts1-new', tiles: [{ key: 'tile2' }] })
         const manager = createManager(gameData, loadTileSet)
 
         await manager.ensureTileSets(['ts1'])
 
         expect(loadTileSet).not.toHaveBeenCalled()
-        expect(gameData.loadedTileSets['ts1']).toEqual({ id: 'ts1' })
+        expect(gameData.loadedTileSets.has('ts1')).toBe(true)
+        expect(gameData.loadedTiles.get('tile1')).toEqual({ key: 'tile1' })
     })
 })


### PR DESCRIPTION
## Summary
- update EngineInitializer tests to include MapManager dependency
- fix MapManager tests for Set and Map storage
- adjust GameDataProvider tests for new game data shape

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_689f421ab56c83328ad63a33fcf552af