### PR TITLE
Log message identifier for missing listeners

### DIFF
--- a/tests/utils/messageBus.test.ts
+++ b/tests/utils/messageBus.test.ts
@@ -33,6 +33,7 @@ describe('MessageBus notification messages', () => {
         bus.registerNotificationMessage('silent')
         bus.postMessage({ message: 'silent' })
 
+        expect(debugSpy).toHaveBeenCalledWith('MessageBus', 'No message listener for message: {0}', 'silent')
         expect(warningSpy).not.toHaveBeenCalled()
 
         debugSpy.mockClear()
@@ -41,6 +42,6 @@ describe('MessageBus notification messages', () => {
         bus.unregisterNotificationMessage('silent')
         bus.postMessage({ message: 'silent' })
 
-        expect(warningSpy).toHaveBeenCalledTimes(1)
+        expect(warningSpy).toHaveBeenCalledWith('MessageBus', 'No message listener for message: {0}', 'silent')
     })
 })

--- a/utils/messageBus.ts
+++ b/utils/messageBus.ts
@@ -152,7 +152,7 @@ export class MessageBus implements IMessageBus {
             const logger = this.silentMessages.has(message.message)
                 ? (msg: string, ...args: unknown[]) => logDebug(logName, msg, ...args)
                 : (msg: string, ...args: unknown[]) => logWarning(logName, msg, ...args)
-            logger('No message listener for message: {0}', message)
+            logger('No message listener for message: {0}', message.message)
             return
         }
         const promises: Promise<void>[] = []


### PR DESCRIPTION
## Summary
- Log missing message listeners using the message identifier only
- Test that message bus logs use the identifier instead of full message objects

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f4fdd674c83329b1604caa53fd2ef