### PR TITLE
docs: add JSDoc to utility types

### DIFF
--- a/utils/types.ts
+++ b/utils/types.ts
@@ -1,15 +1,39 @@
+/**
+ * Function used to clean up resources such as event listeners or subscriptions.
+ *
+ * @example
+ * const stopListening: CleanUp = () => window.removeEventListener('resize', onResize)
+ * window.addEventListener('resize', onResize)
+ * stopListening()
+ */
 export type CleanUp = () => void
 
+/**
+ * Message object transmitted through the message bus.
+ *
+ * @template T - Type of the optional payload included with the message.
+ * @example
+ * const msg: Message<number> = { message: 'ScoreUpdate', payload: 5 }
+ * bus.publish(msg)
+ */
 export interface Message<T = unknown> {
     message: string
     payload?: T
 }
 
+/**
+ * Numeric severity levels for logging.
+ *
+ * @example
+ * logger.log(LogLevel.info, 'Application started')
+ */
 export const LogLevel = {
     debug: 0,
     info: 1,
     warning: 2,
-    error: 3
+    error: 3,
 } as const
+
+/** Type representing the value union of {@link LogLevel}. */
 // eslint-disable-next-line no-redeclare
 export type LogLevel = typeof LogLevel[keyof typeof LogLevel]


### PR DESCRIPTION
## Summary
- document CleanUp as a reusable teardown callback
- clarify Message structure and optional payload
- describe LogLevel severity values for logging

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_689f7e17701883328a70dbc52f7bbd07