### PR TITLE
Add keyboard event listener tests and fix cleanup binding

### DIFF
--- a/tests/utils/keyboardEventListener.test.ts
+++ b/tests/utils/keyboardEventListener.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { KeyboardEventListener } from '../../utils/keyboardEventListener'
+
+describe('KeyboardEventListener', () => {
+    let listener: KeyboardEventListener
+    let handler: ((event: globalThis.KeyboardEvent) => void) | undefined
+    const documentStub = {
+        addEventListener: vi.fn<(type: string, cb: (e: globalThis.KeyboardEvent) => void) => void>((_, cb) => {
+            handler = cb
+        }),
+        removeEventListener: vi.fn<(type: string, cb: (e: globalThis.KeyboardEvent) => void) => void>()
+    }
+
+    beforeEach(() => {
+        handler = undefined
+        vi.stubGlobal('document', documentStub)
+        listener = new KeyboardEventListener()
+    })
+
+    afterEach(() => {
+        vi.unstubAllGlobals()
+        vi.restoreAllMocks()
+    })
+
+    it('addListener triggers callbacks with normalized key data', () => {
+        const callback = vi.fn()
+        listener.addListener(callback)
+
+        const event = {
+            code: 'KeyA',
+            altKey: true,
+            ctrlKey: false,
+            shiftKey: true
+        } as unknown as globalThis.KeyboardEvent
+
+        handler!(event)
+
+        expect(callback).toHaveBeenCalledWith({
+            code: 'KeyA',
+            alt: true,
+            ctrl: false,
+            shift: true
+        })
+    })
+
+    it('cleanup removes DOM listeners and registered callbacks', () => {
+        const callback = vi.fn()
+        listener.addListener(callback)
+        const boundHandler = handler!
+
+        listener.cleanup()
+
+        expect(documentStub.removeEventListener).toHaveBeenCalledWith('keydown', boundHandler)
+
+        boundHandler({
+            code: 'KeyB',
+            altKey: false,
+            ctrlKey: false,
+            shiftKey: false
+        } as unknown as globalThis.KeyboardEvent)
+
+        expect(callback).not.toHaveBeenCalled()
+    })
+})
+

--- a/utils/keyboardEventListener.ts
+++ b/utils/keyboardEventListener.ts
@@ -46,14 +46,16 @@ export const keyboardeventListenerDependencies: Token<unknown>[] = []
 export class KeyboardEventListener implements IKeyboardEventListener {
     private key: number = 0
     private listeners: EventListener[] = []
+    private boundOnKeyDown: (event: globalThis.KeyboardEvent) => void
 
     /**
      * Creates a new `KeyboardEventListener` and starts listening for
      * `keydown` events on the `document`.
      */
     constructor() {
+        this.boundOnKeyDown = this.onKeyDown.bind(this)
         if (typeof document !== 'undefined') {
-            document.addEventListener('keydown', this.onKeyDown.bind(this))
+            document.addEventListener('keydown', this.boundOnKeyDown)
         }
     }
 
@@ -62,7 +64,7 @@ export class KeyboardEventListener implements IKeyboardEventListener {
      */
     public cleanup() {
         if (typeof document !== 'undefined') {
-            document.removeEventListener('keydown', this.onKeyDown)
+            document.removeEventListener('keydown', this.boundOnKeyDown)
         }
         this.listeners = []
     }


### PR DESCRIPTION
## Summary
- ensure KeyboardEventListener stores a bound handler for proper removal
- add tests for normalized key data and cleanup behavior

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f7e214fa48332af52c37a49ed6ef7