### PR TITLE
fix build by updating tests for new virtual input handling

### DIFF
--- a/tests/engine/engineInitializer.test.ts
+++ b/tests/engine/engineInitializer.test.ts
@@ -12,6 +12,7 @@ import type { IPageManager } from '../../engine/managers/pageManager'
 import type { IActionManager } from '../../engine/managers/actionManager'
 import type { IMapManager } from '../../engine/managers/mapManager'
 import type { IVirtualKeyProvider } from '../../engine/providers/virtualKeyProvider'
+import type { IVirtualInputProvider } from '../../engine/providers/virtualInputProvider'
 import type { Game } from '../../engine/loader/data/game'
 
 describe('EngineInitializer', () => {
@@ -42,6 +43,7 @@ describe('EngineInitializer', () => {
     const actionManager = { initialize: vi.fn() } as unknown as IActionManager
     const mapManager = { initialize: vi.fn() } as unknown as IMapManager
     const virtualKeyProvider = { initialize: vi.fn() } as unknown as IVirtualKeyProvider
+    const virtualInputProvider = { initialize: vi.fn() } as unknown as IVirtualInputProvider
 
     const initializer = new EngineInitializer(
       messageBus,
@@ -53,7 +55,8 @@ describe('EngineInitializer', () => {
       pageManager,
       actionManager,
       mapManager,
-      virtualKeyProvider
+      virtualKeyProvider,
+      virtualInputProvider
     )
 
     await initializer.initialize()
@@ -63,6 +66,8 @@ describe('EngineInitializer', () => {
     expect(pageManager.initialize).toHaveBeenCalledTimes(1)
     expect(actionManager.initialize).toHaveBeenCalledTimes(1)
     expect(mapManager.initialize).toHaveBeenCalledTimes(1)
+    expect(virtualKeyProvider.initialize).toHaveBeenCalledTimes(1)
+    expect(virtualInputProvider.initialize).toHaveBeenCalledTimes(1)
     expect(languageManager.setLanguage).toHaveBeenCalledWith('en')
     expect(domManager.setTitle).toHaveBeenCalledWith('Test Game')
     expect(domManager.setCssFile).toHaveBeenCalledTimes(2)

--- a/tests/engine/virtualKeyProvider.test.ts
+++ b/tests/engine/virtualKeyProvider.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { VIRTUAL_INPUT } from '../../engine/messages/system'
+import { VIRTUAL_KEY } from '../../engine/messages/system'
 import { VirtualKeyProvider } from '../../engine/providers/virtualKeyProvider'
 import type { IKeyboardEventListener } from '../../utils/keyboardEventListener'
 import type { IMessageBus } from '../../utils/messageBus'
@@ -7,7 +7,7 @@ import type { IVirtualKeysLoader } from '../../engine/loader/virtualKeysLoader'
 import type { IGameDataProvider } from '../../engine/providers/gameDataProvider'
 
 describe('VirtualKeyProvider', () => {
-  it('initialize loads keys, registers listener, and posts VIRTUAL_INPUT messages', async () => {
+  it('initialize loads keys, registers listener, and posts VIRTUAL_KEY messages', async () => {
     const cleanup = vi.fn()
     const addListener = vi.fn().mockReturnValue(cleanup)
     const keyboardEventListener = { addListener } as unknown as IKeyboardEventListener
@@ -47,7 +47,7 @@ describe('VirtualKeyProvider', () => {
 
     const handler = addListener.mock.calls[0][0]
     handler({ code: 'Space', alt: false, ctrl: false, shift: false })
-    expect(postMessage).toHaveBeenCalledWith({ message: VIRTUAL_INPUT, payload: 'jump' })
+    expect(postMessage).toHaveBeenCalledWith({ message: VIRTUAL_KEY, payload: 'jump' })
   })
 
   it('cleanup unregisters the listener', async () => {


### PR DESCRIPTION
## Summary
- add missing VirtualInputProvider mocks and expectations in EngineInitializer test
- align VirtualKeyProvider test to expect VIRTUAL_KEY messages

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fb7be436c8332a76053363b137600