### PR TITLE
docs: document virtual input provider lifecycle

### DIFF
--- a/engine/providers/virtualInputProvider.ts
+++ b/engine/providers/virtualInputProvider.ts
@@ -5,6 +5,16 @@ import { gameDataProviderToken, IGameDataProvider } from './gameDataProvider'
 import { CleanUp } from '@utils/types'
 import { VIRTUAL_INPUT, VIRTUAL_KEY } from '@messages/system'
 
+/**
+ * Provides access to the game's virtual inputs and manages the lifecycle of
+ * the underlying message listeners.
+ *
+ * - `initialize` loads the virtual input configuration and registers a
+ *   listener so that virtual key messages are translated into virtual input
+ *   events.
+ * - `cleanup` unregisters the listener and releases any resources created
+ *   during initialization.
+ */
 export interface IVirtualInputProvider {
     initialize(): Promise<void>
     cleanup(): void
@@ -26,6 +36,14 @@ export class VirtualInputProvider implements IVirtualInputProvider {
         private gameDataProvider: IGameDataProvider
     ) {}
 
+    /**
+     * Called during engine startup to prepare the virtual input system.
+     * Loads virtual inputs on first use and registers a message listener that
+     * converts virtual key messages into virtual input messages.
+     *
+     * Side effects include populating the `loadedVirtualInputs` map and
+     * storing a cleanup function for later disposal.
+     */
     public async initialize(): Promise<void> {
         if (this.gameDataProvider.Game.loadedVirtualInputs.size === 0) await this.loadVirtualInputs()
         this.CleanUpFn = this.messagebus.registerMessageListener(
@@ -41,11 +59,20 @@ export class VirtualInputProvider implements IVirtualInputProvider {
         )
     }
 
+    /**
+     * Releases resources acquired during initialization by unregistering the
+     * message listener and clearing the stored cleanup function.
+     */
     public cleanup(): void {
         this.CleanUpFn?.()
         this.CleanUpFn = null
     }
 
+    /**
+     * Loads virtual input definitions and populates the
+     * `loadedVirtualInputs` map with the corresponding mappings. Mutates the
+     * game data provider's state.
+     */
     private async loadVirtualInputs(): Promise<void> {
         var inputs = await this.virtualInputsLoader.loadVirtualInputs(this.gameDataProvider.Game.game.virtualInputs)
         inputs.forEach(input => {


### PR DESCRIPTION
## Summary
- document purpose of IVirtualInputProvider and lifecycle responsibilities
- add JSDoc for initialize, cleanup and supporting loader method

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_689fb9df125c833285a1f84296414737