### PR TITLE
test: add virtual input and key loader/provider tests

### DIFF
--- a/tests/engine/virtualInputProvider.test.ts
+++ b/tests/engine/virtualInputProvider.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from 'vitest'
+import { VIRTUAL_INPUT, VIRTUAL_KEY } from '../../engine/messages/system'
+import { VirtualInputProvider } from '../../engine/providers/virtualInputProvider'
+import type { IVirtualInputsLoader } from '../../engine/loader/virtualInputsLoader'
+import type { IMessageBus } from '../../utils/messageBus'
+import type { IGameDataProvider } from '../../engine/providers/gameDataProvider'
+
+// Tests for VirtualInputProvider
+
+describe('VirtualInputProvider', () => {
+  it('initialize loads inputs when needed, registers listener and posts VIRTUAL_INPUT messages', async () => {
+    const loadVirtualInputs = vi.fn().mockResolvedValue([
+      { virtualInput: 'jump', virtualKeys: ['VK_JUMP'], label: 'Jump' }
+    ])
+    const virtualInputsLoader = { loadVirtualInputs } as unknown as IVirtualInputsLoader
+
+    const cleanup = vi.fn()
+    const registerMessageListener = vi.fn().mockReturnValue(cleanup)
+    const postMessage = vi.fn()
+    const messageBus = { registerMessageListener, postMessage } as unknown as IMessageBus
+
+    const gameDataProvider = {
+      Game: {
+        game: { virtualInputs: ['inputs.json'] } as unknown,
+        loadedLanguages: {},
+        loadedPages: {},
+        loadedMaps: {},
+        loadedTiles: new Map(),
+        loadedTileSets: new Set(),
+        loadedVirtualKeys: new Map(),
+        loadedVirtualInputs: new Map()
+      }
+    } as unknown as IGameDataProvider
+
+    const provider = new VirtualInputProvider(
+      virtualInputsLoader,
+      messageBus,
+      gameDataProvider
+    )
+
+    await provider.initialize()
+
+    expect(loadVirtualInputs).toHaveBeenCalledWith(['inputs.json'])
+    expect(registerMessageListener).toHaveBeenCalledWith(VIRTUAL_KEY, expect.any(Function))
+
+    const handler = registerMessageListener.mock.calls[0][1] as (msg: { message: string, payload: unknown }) => void
+    handler({ message: VIRTUAL_KEY, payload: 'VK_JUMP' })
+    expect(postMessage).toHaveBeenCalledWith({ message: VIRTUAL_INPUT, payload: 'jump' })
+  })
+
+  it('cleanup unregisters the listener', async () => {
+    const loadVirtualInputs = vi.fn().mockResolvedValue([])
+    const virtualInputsLoader = { loadVirtualInputs } as unknown as IVirtualInputsLoader
+
+    const cleanup = vi.fn()
+    const registerMessageListener = vi.fn().mockReturnValue(cleanup)
+    const postMessage = vi.fn()
+    const messageBus = { registerMessageListener, postMessage } as unknown as IMessageBus
+
+    const gameDataProvider = {
+      Game: {
+        game: { virtualInputs: ['inputs.json'] } as unknown,
+        loadedLanguages: {},
+        loadedPages: {},
+        loadedMaps: {},
+        loadedTiles: new Map(),
+        loadedTileSets: new Set(),
+        loadedVirtualKeys: new Map(),
+        loadedVirtualInputs: new Map()
+      }
+    } as unknown as IGameDataProvider
+
+    const provider = new VirtualInputProvider(
+      virtualInputsLoader,
+      messageBus,
+      gameDataProvider
+    )
+
+    await provider.initialize()
+    provider.cleanup()
+    expect(cleanup).toHaveBeenCalledTimes(1)
+
+    provider.cleanup()
+    expect(cleanup).toHaveBeenCalledTimes(1)
+  })
+})
+

--- a/tests/engine/virtualInputsLoader.test.ts
+++ b/tests/engine/virtualInputsLoader.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach, Mock } from 'vitest'
+
+vi.mock('@utils/loadJsonResource', () => ({ loadJsonResource: vi.fn() }))
+vi.mock('@loader/mappers/input', () => ({ mapVirtualInputs: vi.fn() }))
+
+import { loadJsonResource } from '@utils/loadJsonResource'
+import { mapVirtualInputs } from '@loader/mappers/input'
+import { VirtualInputsLoader } from '@loader/virtualInputsLoader'
+
+const dataPathProvider = { dataPath: '/base' }
+
+describe('VirtualInputsLoader', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('loads and maps virtual inputs using dataPath', async () => {
+    const schema1: unknown = [{ s: 1 }]
+    const schema2: unknown = [{ s: 2 }]
+    ;(loadJsonResource as unknown as Mock)
+      .mockResolvedValueOnce(schema1)
+      .mockResolvedValueOnce(schema2)
+    ;(mapVirtualInputs as unknown as Mock)
+      .mockReturnValueOnce([{ virtualInput: 'jump', virtualKeys: ['VK_JUMP'], label: 'Jump' }])
+      .mockReturnValueOnce([{ virtualInput: 'run', virtualKeys: ['VK_RUN'], label: 'Run' }])
+
+    const loader = new VirtualInputsLoader(dataPathProvider)
+    const result = await loader.loadVirtualInputs(['v1.json', 'v2.json'])
+
+    expect(loadJsonResource).toHaveBeenNthCalledWith(1, '/base/v1.json', expect.anything())
+    expect(loadJsonResource).toHaveBeenNthCalledWith(2, '/base/v2.json', expect.anything())
+    expect(mapVirtualInputs).toHaveBeenNthCalledWith(1, schema1)
+    expect(mapVirtualInputs).toHaveBeenNthCalledWith(2, schema2)
+    expect(result).toEqual([
+      { virtualInput: 'jump', virtualKeys: ['VK_JUMP'], label: 'Jump' },
+      { virtualInput: 'run', virtualKeys: ['VK_RUN'], label: 'Run' }
+    ])
+  })
+
+  it('throws when no virtual inputs paths provided', async () => {
+    const loader = new VirtualInputsLoader(dataPathProvider)
+    await expect(loader.loadVirtualInputs([])).rejects.toThrow('No virtual inputs paths provided')
+  })
+})
+

--- a/tests/engine/virtualKeysLoader.test.ts
+++ b/tests/engine/virtualKeysLoader.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach, Mock } from 'vitest'
+
+vi.mock('@utils/loadJsonResource', () => ({ loadJsonResource: vi.fn() }))
+vi.mock('@loader/mappers/input', () => ({ mapVirtualKeys: vi.fn() }))
+
+import { loadJsonResource } from '@utils/loadJsonResource'
+import { mapVirtualKeys } from '@loader/mappers/input'
+import { VirtualKeysLoader } from '@loader/virtualKeysLoader'
+
+const dataPathProvider = { dataPath: '/base' }
+
+describe('VirtualKeysLoader', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('loads and maps virtual keys using dataPath', async () => {
+    const schema1: unknown = [{ s: 1 }]
+    const schema2: unknown = [{ s: 2 }]
+    ;(loadJsonResource as unknown as Mock)
+      .mockResolvedValueOnce(schema1)
+      .mockResolvedValueOnce(schema2)
+    ;(mapVirtualKeys as unknown as Mock)
+      .mockReturnValueOnce([{ virtualKey: 'jump', keyCode: 'Space', alt: false, ctrl: false, shift: false }])
+      .mockReturnValueOnce([{ virtualKey: 'run', keyCode: 'KeyR', alt: false, ctrl: false, shift: false }])
+
+    const loader = new VirtualKeysLoader(dataPathProvider)
+    const result = await loader.loadVirtualKeys(['k1.json', 'k2.json'])
+
+    expect(loadJsonResource).toHaveBeenNthCalledWith(1, '/base/k1.json', expect.anything())
+    expect(loadJsonResource).toHaveBeenNthCalledWith(2, '/base/k2.json', expect.anything())
+    expect(mapVirtualKeys).toHaveBeenNthCalledWith(1, schema1)
+    expect(mapVirtualKeys).toHaveBeenNthCalledWith(2, schema2)
+    expect(result).toEqual([
+      { virtualKey: 'jump', keyCode: 'Space', alt: false, ctrl: false, shift: false },
+      { virtualKey: 'run', keyCode: 'KeyR', alt: false, ctrl: false, shift: false }
+    ])
+  })
+
+  it('throws when no virtual keys paths provided', async () => {
+    const loader = new VirtualKeysLoader(dataPathProvider)
+    await expect(loader.loadVirtualKeys([])).rejects.toThrow('No virtual keys paths provided')
+  })
+})
+


### PR DESCRIPTION
## Summary
- add unit tests for VirtualInputProvider to load inputs, forward virtual key messages, and cleanup listeners
- cover VirtualInputsLoader path mapping and error handling
- cover VirtualKeysLoader path mapping and error handling

## Testing
- `npm run lint`
- `npm run build`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_689fb9e70dd8833292c2a996dc6d75bf