### PR TITLE
test: add config provider container tests

### DIFF
--- a/tests/engine/configProviders.test.ts
+++ b/tests/engine/configProviders.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest'
+import { Container } from '@ioc/container'
+import { dataPathProviderToken, type IDataPathProvider } from '@providers/configProviders'
+
+describe('configProviders', () => {
+  it('provides dataPath via the DI container', () => {
+    const container = new Container()
+    const provider: IDataPathProvider = { dataPath: '/test/data' }
+    container.register({ token: dataPathProviderToken, useValue: provider })
+
+    const resolved = container.resolve(dataPathProviderToken)
+    expect(resolved.dataPath).toBe('/test/data')
+  })
+
+  it('throws when dataPathProvider is not registered', () => {
+    const container = new Container()
+    expect(() => container.resolve(dataPathProviderToken))
+      .toThrowError('[Container] No provider for DataPathProvider')
+  })
+})
+


### PR DESCRIPTION
## Summary
- add tests covering dataPath provider token retrieval and missing registration errors

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fb9ee486c83329707cd6d00877e49