### PR TITLE
test: ensure loaders surface fatal errors

### DIFF
--- a/tests/engine/actionHandlersLoader.test.ts
+++ b/tests/engine/actionHandlersLoader.test.ts
@@ -1,9 +1,15 @@
 import { describe, it, expect, vi, beforeEach, Mock } from 'vitest'
 
+vi.mock('@utils/logMessage', () => ({
+  fatalError: vi.fn((categoryOrMessage: string, message?: string) => {
+    throw new Error(message ?? categoryOrMessage)
+  })
+}))
 vi.mock('@utils/loadJsonResource', () => ({ loadJsonResource: vi.fn() }))
 vi.mock('@loader/mappers/handler', () => ({ mapHandlers: vi.fn() }))
 
 import { loadJsonResource } from '@utils/loadJsonResource'
+import { fatalError } from '@utils/logMessage'
 import { mapHandlers } from '@loader/mappers/handler'
 import { ActionHandlersLoader } from '@loader/actionHandlersLoader'
 
@@ -37,5 +43,31 @@ describe('ActionHandlersLoader', () => {
   it('throws when no handler paths provided', async () => {
     const loader = new ActionHandlersLoader(dataPathProvider)
     await expect(loader.loadActions([])).rejects.toThrow('No action handlers paths provided')
+  })
+
+  it('throws when loadJsonResource rejects', async () => {
+    ;(fatalError as unknown as Mock).mockImplementation(() => {
+      throw new Error('fatal')
+    })
+    ;(loadJsonResource as unknown as Mock).mockImplementation(() => fatalError('fail'))
+
+    const loader = new ActionHandlersLoader(dataPathProvider)
+    await expect(loader.loadActions(['a.json'])).rejects.toThrow('fatal')
+
+    expect(fatalError).toHaveBeenCalled()
+    expect(mapHandlers).not.toHaveBeenCalled()
+  })
+
+  it('throws when loadJsonResource returns invalid data', async () => {
+    ;(loadJsonResource as unknown as Mock).mockResolvedValue({})
+    ;(fatalError as unknown as Mock).mockImplementation(() => {
+      throw new Error('fatal')
+    })
+    ;(mapHandlers as unknown as Mock).mockImplementation(() => fatalError('invalid'))
+
+    const loader = new ActionHandlersLoader(dataPathProvider)
+    await expect(loader.loadActions(['a.json'])).rejects.toThrow('fatal')
+
+    expect(fatalError).toHaveBeenCalled()
   })
 })

--- a/tests/engine/gameLoader.test.ts
+++ b/tests/engine/gameLoader.test.ts
@@ -1,9 +1,15 @@
 import { describe, it, expect, vi, beforeEach, Mock } from 'vitest'
 
+vi.mock('@utils/logMessage', () => ({
+  fatalError: vi.fn((categoryOrMessage: string, message?: string) => {
+    throw new Error(message ?? categoryOrMessage)
+  })
+}))
 vi.mock('@utils/loadJsonResource', () => ({ loadJsonResource: vi.fn() }))
 vi.mock('@loader/mappers/game', () => ({ mapGame: vi.fn() }))
 
 import { loadJsonResource } from '@utils/loadJsonResource'
+import { fatalError } from '@utils/logMessage'
 import { mapGame } from '@loader/mappers/game'
 import { GameLoader } from '@loader/gameLoader'
 
@@ -26,5 +32,31 @@ describe('GameLoader', () => {
     expect(loadJsonResource).toHaveBeenCalledWith('/base/index.json', expect.anything())
     expect(mapGame).toHaveBeenCalledWith(schema, '/base')
     expect(result).toBe(mapped)
+  })
+
+  it('throws when loadJsonResource rejects', async () => {
+    ;(fatalError as unknown as Mock).mockImplementation(() => {
+      throw new Error('fatal')
+    })
+    ;(loadJsonResource as unknown as Mock).mockImplementation(() => fatalError('fail'))
+
+    const loader = new GameLoader(dataPathProvider)
+    await expect(loader.loadGame()).rejects.toThrow('fatal')
+
+    expect(fatalError).toHaveBeenCalled()
+    expect(mapGame).not.toHaveBeenCalled()
+  })
+
+  it('throws when loadJsonResource returns invalid data', async () => {
+    ;(loadJsonResource as unknown as Mock).mockResolvedValue({})
+    ;(fatalError as unknown as Mock).mockImplementation(() => {
+      throw new Error('fatal')
+    })
+    ;(mapGame as unknown as Mock).mockImplementation(() => fatalError('invalid'))
+
+    const loader = new GameLoader(dataPathProvider)
+    await expect(loader.loadGame()).rejects.toThrow('fatal')
+
+    expect(fatalError).toHaveBeenCalled()
   })
 })

--- a/tests/engine/languageLoader.test.ts
+++ b/tests/engine/languageLoader.test.ts
@@ -1,9 +1,15 @@
 import { describe, it, expect, vi, beforeEach, Mock } from 'vitest'
 
+vi.mock('@utils/logMessage', () => ({
+  fatalError: vi.fn((categoryOrMessage: string, message?: string) => {
+    throw new Error(message ?? categoryOrMessage)
+  })
+}))
 vi.mock('@utils/loadJsonResource', () => ({ loadJsonResource: vi.fn() }))
 vi.mock('@loader/mappers/language', () => ({ mapLanguage: vi.fn() }))
 
 import { loadJsonResource } from '@utils/loadJsonResource'
+import { fatalError } from '@utils/logMessage'
 import { mapLanguage } from '@loader/mappers/language'
 import { LanguageLoader } from '@loader/languageLoader'
 
@@ -52,5 +58,31 @@ describe('LanguageLoader', () => {
 
     const loader = new LanguageLoader(dataPathProvider)
     await expect(loader.loadLanguage(['a.json', 'b.json'])).rejects.toThrow(/Language ID mismatch/)
+  })
+
+  it('throws when loadJsonResource rejects', async () => {
+    ;(fatalError as unknown as Mock).mockImplementation(() => {
+      throw new Error('fatal')
+    })
+    ;(loadJsonResource as unknown as Mock).mockImplementation(() => fatalError('fail'))
+
+    const loader = new LanguageLoader(dataPathProvider)
+    await expect(loader.loadLanguage(['a.json'])).rejects.toThrow('fatal')
+
+    expect(fatalError).toHaveBeenCalled()
+    expect(mapLanguage).not.toHaveBeenCalled()
+  })
+
+  it('throws when loadJsonResource returns invalid data', async () => {
+    ;(loadJsonResource as unknown as Mock).mockResolvedValue({})
+    ;(fatalError as unknown as Mock).mockImplementation(() => {
+      throw new Error('fatal')
+    })
+    ;(mapLanguage as unknown as Mock).mockImplementation(() => fatalError('invalid'))
+
+    const loader = new LanguageLoader(dataPathProvider)
+    await expect(loader.loadLanguage(['a.json'])).rejects.toThrow('fatal')
+
+    expect(fatalError).toHaveBeenCalled()
   })
 })

--- a/tests/engine/pageLoader.test.ts
+++ b/tests/engine/pageLoader.test.ts
@@ -1,9 +1,15 @@
 import { describe, it, expect, vi, beforeEach, Mock } from 'vitest'
 
+vi.mock('@utils/logMessage', () => ({
+  fatalError: vi.fn((categoryOrMessage: string, message?: string) => {
+    throw new Error(message ?? categoryOrMessage)
+  })
+}))
 vi.mock('@utils/loadJsonResource', () => ({ loadJsonResource: vi.fn() }))
 vi.mock('@loader/mappers/page', () => ({ mapPage: vi.fn() }))
 
 import { loadJsonResource } from '@utils/loadJsonResource'
+import { fatalError } from '@utils/logMessage'
 import { mapPage } from '@loader/mappers/page'
 import { PageLoader } from '@loader/pageLoader'
 
@@ -26,5 +32,31 @@ describe('PageLoader', () => {
     expect(loadJsonResource).toHaveBeenCalledWith('/base/pages/start.json', expect.anything())
     expect(mapPage).toHaveBeenCalledWith('/base', schema)
     expect(result).toBe(mapped)
+  })
+
+  it('throws when loadJsonResource rejects', async () => {
+    ;(fatalError as unknown as Mock).mockImplementation(() => {
+      throw new Error('fatal')
+    })
+    ;(loadJsonResource as unknown as Mock).mockImplementation(() => fatalError('fail'))
+
+    const loader = new PageLoader(dataPathProvider)
+    await expect(loader.loadPage('pages/start.json')).rejects.toThrow('fatal')
+
+    expect(fatalError).toHaveBeenCalled()
+    expect(mapPage).not.toHaveBeenCalled()
+  })
+
+  it('throws when loadJsonResource returns invalid data', async () => {
+    ;(loadJsonResource as unknown as Mock).mockResolvedValue({})
+    ;(fatalError as unknown as Mock).mockImplementation(() => {
+      throw new Error('fatal')
+    })
+    ;(mapPage as unknown as Mock).mockImplementation(() => fatalError('invalid'))
+
+    const loader = new PageLoader(dataPathProvider)
+    await expect(loader.loadPage('pages/start.json')).rejects.toThrow('fatal')
+
+    expect(fatalError).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary
- add failing data tests to loader suites
- verify fatalError is called when loadJsonResource rejects or returns invalid data

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_689fba14c4a4833292d925bc472ca707