### PR TITLE
refactor: modularize container assembly

### DIFF
--- a/engine/builders/actionsBuilder.ts
+++ b/engine/builders/actionsBuilder.ts
@@ -1,0 +1,26 @@
+import { Container } from '@ioc/container'
+import { ActionExecuter, actionExecuterDependencies, actionExecuterToken } from '@actions/actionExecuter'
+import { PostMessageAction, PostMessageActionDependencies, postMessageActionToken } from '@actions/postMessageAction'
+
+/**
+ * Registers action related services and predefined actions.
+ */
+export class ActionsBuilder {
+  /**
+   * Register action dependencies into the container.
+   */
+  register(container: Container): void {
+    container.register({
+      token: actionExecuterToken,
+      useClass: ActionExecuter,
+      deps: actionExecuterDependencies
+    })
+    container.register({
+      token: postMessageActionToken,
+      useClass: PostMessageAction,
+      deps: PostMessageActionDependencies,
+      scope: 'transient'
+    })
+  }
+}
+

--- a/engine/builders/containerBuilder.ts
+++ b/engine/builders/containerBuilder.ts
@@ -1,290 +1,56 @@
-import { GameEngine, gameEngineDependencies, gameEngineToken } from '@engine/gameEngine'
-import { TurnScheduler, turnSchedulerDependencies, turnSchedulerToken } from '@engine/turnScheduler'
 import { Container } from '@ioc/container'
 import type { Container as IContainer } from '@ioc/types'
-import { MessageBus, messageBusDependencies, messageBusToken } from '@utils/messageBus'
-import { MessageQueue, messageQueueToken } from '@utils/messageQueue'
-import { GameLoader, gameLoaderToken } from '@loader/gameLoader'
-import { LanguageLoader, languageLoaderDependencies, languageLoaderToken } from '@loader/languageLoader'
-import { EngineInitializer, engineInitializerDependencies, engineInitializerToken } from '@engine/engineInitializer'
-import { PageLoader, pageLoaderDependencies, pageLoaderToken } from '@loader/pageLoader'
-import { dataPathProviderToken, IDataPathProvider } from '@providers/configProviders'
-import { GameDataProvider, gameDataProviderDependencies, gameDataProviderToken } from '@providers/gameDataProvider'
-import { TranslationService, translationServiceToken } from '@services/translationService'
-import { DomManager, domManagerDependencies, domManagerToken } from '@managers/domManager'
-import { LanguageManager, languageManagerDependencies, languageManagerToken } from '@managers/languageManager'
-import { PageManager, pageManagerDependencies, pageManagerToken } from '@managers/pageManager'
-import { ServiceProvider, serviceProviderToken } from '@providers/serviceProvider'
-import { ActionHandlerRegistry, actionHandlerRegistryDependencies, actionHandlerRegistryToken } from '@registries/actionHandlerRegistry'
-import { ConditionResolverRegistry, conditionResolverRegistryDependencies, conditionResolverRegistryToken } from '@registries/conditionResolverRegistry'
-import { ComponentRegistry, componentRegistryDependencies, componentRegistryToken } from '@registries/componentRegistry'
-import { ActionExecuter, actionExecuterDependencies, actionExecuterToken } from '@actions/actionExecuter'
-import { PostMessageAction, PostMessageActionDependencies, postMessageActionToken } from '@actions/postMessageAction'
-import { ActionHandlersLoader, actionHandlersLoaderDependencies, actionHandlersLoaderToken } from '@loader/actionHandlersLoader'
-import { ActionManager, actionManagerDependencies, actionManagerToken } from '@managers/actionManager'
-import { GameMapLoader, gameMapLoaderDependencies, gameMapLoaderToken } from '@loader/gameMapLoader'
-import { TileSetLoader, tileSetLoaderDependencies, tileSetLoaderToken } from '@loader/tileSetLoader'
-import { MapManager, mapManagerDependencies, mapManagerToken } from '@managers/mapManager'
-import { VirtualKeysLoader, virtualKeysLoaderDependencies, virtualKeysLoaderToken } from '@loader/virtualKeysLoader'
-import { KeyboardEventListener, keyboardeventListenerDependencies, keyboardeventListenerToken } from '@utils/keyboardEventListener'
-import { VirtualKeyProvider, virtualKeyProviderDependencies, virtualKeyProviderToken } from '@providers/virtualKeyProvider'
-import { VirtualInputsLoader, virtualInputsLoaderDependencies, virtualInputsLoaderToken } from '@loader/virtualInputsLoader'
-import { VirtualInputProvider, virtualInputProviderDependencies, virtualInputProviderToken } from '@providers/virtualInputProvider'
+
+import { ActionsBuilder } from './actionsBuilder'
+import { CoreBuilder } from './coreBuilder'
+import { LoadersBuilder } from './loadersBuilder'
+import { ManagersBuilder } from './managersBuilder'
+import { ProvidersBuilder } from './providersBuilder'
+import { RegistriesBuilder } from './registriesBuilder'
+import { ServicesBuilder } from './servicesBuilder'
 
 /**
  * Builder abstraction for creating and configuring a dependency injection container.
  */
 export interface IContainerBuilder {
-    /**
-     * Construct and configure a service container.
-     *
-     * @returns A fully configured container instance.
-     */
-    build(): Container
+  /**
+   * Construct and configure a service container.
+   *
+   * @returns A fully configured container instance.
+   */
+  build(): Container
 }
 
 /**
  * Wires together all engine components using dependency injection.
  */
 export class ContainerBuilder implements IContainerBuilder {
-    /**
-     * @param onQueueEmptyProvider Factory for creating callbacks when the message queue empties.
-     * @param dataPath Base path for loading game data resources.
-     */
-    constructor(
-        private onQueueEmptyProvider: (container: IContainer) => () => void = () => () => {},
-        private dataPath: string = process.env.DATA_PATH ?? '/data',
-    ) {}
+  /**
+   * @param onQueueEmptyProvider Factory for creating callbacks when the message queue empties.
+   * @param dataPath Base path for loading game data resources.
+   */
+  constructor(
+    private onQueueEmptyProvider: (container: IContainer) => () => void = () => () => {},
+    private dataPath: string = process.env.DATA_PATH ?? '/data',
+  ) {}
 
-    /**
-     * Build and configure the dependency container.
-     *
-     * @returns Populated container instance.
-     * @remarks Mutates the new container by registering all engine services.
-     */
-    public build(): Container {
-        const result = new Container()
-        this.registerCore(result)
-        this.registerProviders(result)
-        this.registerLoaders(result)
-        this.registerServices(result)
-        this.registerRegistries(result)
-        this.registerManagers(result)
-        this.registerActions(result)
-        // Hook for custom service registrations
-        return result
-    }
-
-    /**
-     * Register core engine dependencies including the turn scheduler, message
-     * queue, message bus, engine initializer, and the game engine itself.
-     *
-     * @param container Container to receive registrations.
-     * @remarks Mutates the provided container.
-     */
-    private registerCore(container: Container): void {
-        container.register({
-            token: turnSchedulerToken,
-            useClass: TurnScheduler,
-            deps: turnSchedulerDependencies
-        })
-        container.register({
-            token: messageQueueToken,
-            useFactory: (c) => new MessageQueue(this.onQueueEmptyProvider(c))
-        })
-        container.register({
-            token: messageBusToken,
-            useClass: MessageBus,
-            deps: messageBusDependencies
-        })
-        container.register({
-            token: engineInitializerToken,
-            useClass: EngineInitializer,
-            deps: engineInitializerDependencies
-        })
-        container.register({
-            token: gameEngineToken,
-            useClass: GameEngine,
-            deps: gameEngineDependencies
-        })
-        container.register({
-            token: keyboardeventListenerToken,
-            useClass: KeyboardEventListener,
-            deps: keyboardeventListenerDependencies
-        })
-    }
-
-    /**
-     * Register action-related services like executers and predefined actions.
-     *
-     * @param container Container to receive action registrations.
-     * @remarks Mutates the provided container.
-     */
-    private registerActions(container: Container): void {
-        container.register({
-            token: actionExecuterToken,
-            useClass: ActionExecuter,
-            deps: actionExecuterDependencies
-        })
-        container.register({
-            token: postMessageActionToken,
-            useClass: PostMessageAction,
-            deps: PostMessageActionDependencies,
-            scope: 'transient'
-        })
-    }
-
-    /**
-     * Registers provider components like configuration and data providers.
-     *
-     * @param container Container to receive provider registrations.
-     * @remarks Mutates the provided container.
-     */
-    private registerProviders(container: Container): void {
-        container.register({
-            token: serviceProviderToken,
-            useFactory: c => new ServiceProvider(c)
-        })
-        container.register<IDataPathProvider>({
-            token: dataPathProviderToken,
-            useValue: { dataPath: this.dataPath }
-        })
-        container.register({
-            token: gameDataProviderToken,
-            useClass: GameDataProvider,
-            deps: gameDataProviderDependencies
-        })
-        container.register({
-            token: virtualKeyProviderToken,
-            useClass: VirtualKeyProvider,
-            deps: virtualKeyProviderDependencies
-        })
-        container.register({
-            token: virtualInputProviderToken,
-            useClass: VirtualInputProvider,
-            deps: virtualInputProviderDependencies
-        })
-    }
-
-    /**
-     * Register loaders responsible for fetching game, language and page data.
-     *
-     * @param container Container to receive registrations.
-     * @remarks Mutates the provided container.
-     */
-    private registerLoaders(container: Container): void {
-        container.register({
-            token: gameLoaderToken,
-            useClass: GameLoader,
-            deps: [dataPathProviderToken]
-        })
-        container.register({
-            token: languageLoaderToken,
-            useClass: LanguageLoader,
-            deps: languageLoaderDependencies
-        })
-        container.register({
-            token: pageLoaderToken,
-            useClass: PageLoader,
-            deps: pageLoaderDependencies
-        })
-        container.register({
-            token: actionHandlersLoaderToken,
-            useClass: ActionHandlersLoader,
-            deps: actionHandlersLoaderDependencies
-        })
-        container.register({
-            token: gameMapLoaderToken,
-            useClass: GameMapLoader,
-            deps: gameMapLoaderDependencies
-        })
-        container.register({
-            token: tileSetLoaderToken,
-            useClass: TileSetLoader,
-            deps: tileSetLoaderDependencies
-        })
-        container.register({
-            token: virtualKeysLoaderToken,
-            useClass: VirtualKeysLoader,
-            deps: virtualKeysLoaderDependencies
-        })
-        container.register({
-            token: virtualInputsLoaderToken,
-            useClass: VirtualInputsLoader,
-            deps: virtualInputsLoaderDependencies
-        })
-    }
-
-    /**
-     * Register application services such as translation.
-     *
-     * @param container Container to receive registrations.
-     * @remarks Mutates the provided container.
-     */
-    private registerServices(container: Container): void {
-        container.register({
-            token: translationServiceToken,
-            useClass: TranslationService,
-            deps: []
-        })
-    }
-
-    /**
-     * Register registries used for dynamic lookups such as action handlers.
-     *
-     * @param container Container to receive registrations.
-     * @remarks Mutates the provided container.
-     */
-    private registerRegistries(container: Container): void {
-        container.register({
-            token: actionHandlerRegistryToken,
-            useClass: ActionHandlerRegistry,
-            deps: actionHandlerRegistryDependencies
-        })
-        container.register({
-            token: conditionResolverRegistryToken,
-            useClass: ConditionResolverRegistry,
-            deps: conditionResolverRegistryDependencies
-        })
-        container.register({
-            token: componentRegistryToken,
-            useClass: ComponentRegistry,
-            deps: componentRegistryDependencies
-        })
-    }
-
-    /**
-     * Register manager classes that orchestrate DOM, language and pages.
-     *
-     * @param container Container to receive registrations.
-     * @remarks Mutates the provided container.
-     */
-    private registerManagers(container: Container): void {
-        container.register({
-            token: domManagerToken,
-            useClass: DomManager,
-            deps: domManagerDependencies,
-            scope: 'transient'
-        })
-        container.register({
-            token: languageManagerToken,
-            useClass: LanguageManager,
-            deps: languageManagerDependencies
-        })
-        container.register({
-            token: pageManagerToken,
-            useClass: PageManager,
-            deps: pageManagerDependencies
-        })
-        container.register({
-            token: actionManagerToken,
-            useClass: ActionManager,
-            deps: actionManagerDependencies
-        })
-        container.register({
-            token: mapManagerToken,
-            useClass: MapManager,
-            deps: mapManagerDependencies
-        })
-    }
+  /**
+   * Build and configure the dependency container.
+   *
+   * @returns Populated container instance.
+   * @remarks Mutates the new container by registering all engine services.
+   */
+  public build(): Container {
+    const result = new Container()
+    new CoreBuilder(this.onQueueEmptyProvider).register(result)
+    new ProvidersBuilder(this.dataPath).register(result)
+    new LoadersBuilder().register(result)
+    new ServicesBuilder().register(result)
+    new RegistriesBuilder().register(result)
+    new ManagersBuilder().register(result)
+    new ActionsBuilder().register(result)
+    // Hook for custom service registrations
+    return result
+  }
 }
+

--- a/engine/builders/coreBuilder.ts
+++ b/engine/builders/coreBuilder.ts
@@ -1,0 +1,51 @@
+import { GameEngine, gameEngineDependencies, gameEngineToken } from '@engine/gameEngine'
+import { TurnScheduler, turnSchedulerDependencies, turnSchedulerToken } from '@engine/turnScheduler'
+import { EngineInitializer, engineInitializerDependencies, engineInitializerToken } from '@engine/engineInitializer'
+import { Container } from '@ioc/container'
+import type { Container as IContainer } from '@ioc/types'
+import { MessageBus, messageBusDependencies, messageBusToken } from '@utils/messageBus'
+import { MessageQueue, messageQueueToken } from '@utils/messageQueue'
+import { KeyboardEventListener, keyboardeventListenerDependencies, keyboardeventListenerToken } from '@utils/keyboardEventListener'
+
+/**
+ * Registers core engine services like the game engine and messaging infrastructure.
+ */
+export class CoreBuilder {
+  constructor(private onQueueEmptyProvider: (container: IContainer) => () => void = () => () => {}) {}
+
+  /**
+   * Register core dependencies into the container.
+   */
+  register(container: Container): void {
+    container.register({
+      token: turnSchedulerToken,
+      useClass: TurnScheduler,
+      deps: turnSchedulerDependencies
+    })
+    container.register({
+      token: messageQueueToken,
+      useFactory: c => new MessageQueue(this.onQueueEmptyProvider(c))
+    })
+    container.register({
+      token: messageBusToken,
+      useClass: MessageBus,
+      deps: messageBusDependencies
+    })
+    container.register({
+      token: engineInitializerToken,
+      useClass: EngineInitializer,
+      deps: engineInitializerDependencies
+    })
+    container.register({
+      token: gameEngineToken,
+      useClass: GameEngine,
+      deps: gameEngineDependencies
+    })
+    container.register({
+      token: keyboardeventListenerToken,
+      useClass: KeyboardEventListener,
+      deps: keyboardeventListenerDependencies
+    })
+  }
+}
+

--- a/engine/builders/loadersBuilder.ts
+++ b/engine/builders/loadersBuilder.ts
@@ -1,0 +1,62 @@
+import { Container } from '@ioc/container'
+import { ActionHandlersLoader, actionHandlersLoaderDependencies, actionHandlersLoaderToken } from '@loader/actionHandlersLoader'
+import { GameLoader, gameLoaderToken } from '@loader/gameLoader'
+import { GameMapLoader, gameMapLoaderDependencies, gameMapLoaderToken } from '@loader/gameMapLoader'
+import { LanguageLoader, languageLoaderDependencies, languageLoaderToken } from '@loader/languageLoader'
+import { PageLoader, pageLoaderDependencies, pageLoaderToken } from '@loader/pageLoader'
+import { TileSetLoader, tileSetLoaderDependencies, tileSetLoaderToken } from '@loader/tileSetLoader'
+import { VirtualInputsLoader, virtualInputsLoaderDependencies, virtualInputsLoaderToken } from '@loader/virtualInputsLoader'
+import { VirtualKeysLoader, virtualKeysLoaderDependencies, virtualKeysLoaderToken } from '@loader/virtualKeysLoader'
+import { dataPathProviderToken } from '@providers/configProviders'
+
+/**
+ * Registers loader components responsible for fetching game resources.
+ */
+export class LoadersBuilder {
+  /**
+   * Register loader dependencies into the container.
+   */
+  register(container: Container): void {
+    container.register({
+      token: gameLoaderToken,
+      useClass: GameLoader,
+      deps: [dataPathProviderToken]
+    })
+    container.register({
+      token: languageLoaderToken,
+      useClass: LanguageLoader,
+      deps: languageLoaderDependencies
+    })
+    container.register({
+      token: pageLoaderToken,
+      useClass: PageLoader,
+      deps: pageLoaderDependencies
+    })
+    container.register({
+      token: actionHandlersLoaderToken,
+      useClass: ActionHandlersLoader,
+      deps: actionHandlersLoaderDependencies
+    })
+    container.register({
+      token: gameMapLoaderToken,
+      useClass: GameMapLoader,
+      deps: gameMapLoaderDependencies
+    })
+    container.register({
+      token: tileSetLoaderToken,
+      useClass: TileSetLoader,
+      deps: tileSetLoaderDependencies
+    })
+    container.register({
+      token: virtualKeysLoaderToken,
+      useClass: VirtualKeysLoader,
+      deps: virtualKeysLoaderDependencies
+    })
+    container.register({
+      token: virtualInputsLoaderToken,
+      useClass: VirtualInputsLoader,
+      deps: virtualInputsLoaderDependencies
+    })
+  }
+}
+

--- a/engine/builders/managersBuilder.ts
+++ b/engine/builders/managersBuilder.ts
@@ -1,0 +1,44 @@
+import { Container } from '@ioc/container'
+import { ActionManager, actionManagerDependencies, actionManagerToken } from '@managers/actionManager'
+import { DomManager, domManagerDependencies, domManagerToken } from '@managers/domManager'
+import { LanguageManager, languageManagerDependencies, languageManagerToken } from '@managers/languageManager'
+import { MapManager, mapManagerDependencies, mapManagerToken } from '@managers/mapManager'
+import { PageManager, pageManagerDependencies, pageManagerToken } from '@managers/pageManager'
+
+/**
+ * Registers manager classes that orchestrate major engine systems.
+ */
+export class ManagersBuilder {
+  /**
+   * Register manager dependencies into the container.
+   */
+  register(container: Container): void {
+    container.register({
+      token: domManagerToken,
+      useClass: DomManager,
+      deps: domManagerDependencies,
+      scope: 'transient'
+    })
+    container.register({
+      token: languageManagerToken,
+      useClass: LanguageManager,
+      deps: languageManagerDependencies
+    })
+    container.register({
+      token: pageManagerToken,
+      useClass: PageManager,
+      deps: pageManagerDependencies
+    })
+    container.register({
+      token: actionManagerToken,
+      useClass: ActionManager,
+      deps: actionManagerDependencies
+    })
+    container.register({
+      token: mapManagerToken,
+      useClass: MapManager,
+      deps: mapManagerDependencies
+    })
+  }
+}
+

--- a/engine/builders/providersBuilder.ts
+++ b/engine/builders/providersBuilder.ts
@@ -1,0 +1,43 @@
+import { Container } from '@ioc/container'
+import { dataPathProviderToken, IDataPathProvider } from '@providers/configProviders'
+import { GameDataProvider, gameDataProviderDependencies, gameDataProviderToken } from '@providers/gameDataProvider'
+import { ServiceProvider, serviceProviderToken } from '@providers/serviceProvider'
+import { VirtualInputProvider, virtualInputProviderDependencies, virtualInputProviderToken } from '@providers/virtualInputProvider'
+import { VirtualKeyProvider, virtualKeyProviderDependencies, virtualKeyProviderToken } from '@providers/virtualKeyProvider'
+
+/**
+ * Registers provider services for data, configuration and input.
+ */
+export class ProvidersBuilder {
+  constructor(private dataPath: string) {}
+
+  /**
+   * Register provider dependencies into the container.
+   */
+  register(container: Container): void {
+    container.register({
+      token: serviceProviderToken,
+      useFactory: c => new ServiceProvider(c)
+    })
+    container.register<IDataPathProvider>({
+      token: dataPathProviderToken,
+      useValue: { dataPath: this.dataPath }
+    })
+    container.register({
+      token: gameDataProviderToken,
+      useClass: GameDataProvider,
+      deps: gameDataProviderDependencies
+    })
+    container.register({
+      token: virtualKeyProviderToken,
+      useClass: VirtualKeyProvider,
+      deps: virtualKeyProviderDependencies
+    })
+    container.register({
+      token: virtualInputProviderToken,
+      useClass: VirtualInputProvider,
+      deps: virtualInputProviderDependencies
+    })
+  }
+}
+

--- a/engine/builders/registriesBuilder.ts
+++ b/engine/builders/registriesBuilder.ts
@@ -1,0 +1,31 @@
+import { Container } from '@ioc/container'
+import { ActionHandlerRegistry, actionHandlerRegistryDependencies, actionHandlerRegistryToken } from '@registries/actionHandlerRegistry'
+import { ConditionResolverRegistry, conditionResolverRegistryDependencies, conditionResolverRegistryToken } from '@registries/conditionResolverRegistry'
+import { ComponentRegistry, componentRegistryDependencies, componentRegistryToken } from '@registries/componentRegistry'
+
+/**
+ * Registers dynamic registries for actions, components and conditions.
+ */
+export class RegistriesBuilder {
+  /**
+   * Register registry dependencies into the container.
+   */
+  register(container: Container): void {
+    container.register({
+      token: actionHandlerRegistryToken,
+      useClass: ActionHandlerRegistry,
+      deps: actionHandlerRegistryDependencies
+    })
+    container.register({
+      token: conditionResolverRegistryToken,
+      useClass: ConditionResolverRegistry,
+      deps: conditionResolverRegistryDependencies
+    })
+    container.register({
+      token: componentRegistryToken,
+      useClass: ComponentRegistry,
+      deps: componentRegistryDependencies
+    })
+  }
+}
+

--- a/engine/builders/servicesBuilder.ts
+++ b/engine/builders/servicesBuilder.ts
@@ -1,0 +1,19 @@
+import { Container } from '@ioc/container'
+import { TranslationService, translationServiceToken } from '@services/translationService'
+
+/**
+ * Registers application level services.
+ */
+export class ServicesBuilder {
+  /**
+   * Register service dependencies into the container.
+   */
+  register(container: Container): void {
+    container.register({
+      token: translationServiceToken,
+      useClass: TranslationService,
+      deps: []
+    })
+  }
+}
+

--- a/tests/engine/containerBuilder.test.ts
+++ b/tests/engine/containerBuilder.test.ts
@@ -14,6 +14,7 @@ import { VirtualKeyProvider, virtualKeyProviderToken } from '@providers/virtualK
 import { VirtualInputProvider, virtualInputProviderToken } from '@providers/virtualInputProvider'
 import { Container } from '@ioc/container'
 import type { Token } from '@ioc/token'
+import { ProvidersBuilder } from '@builders/providersBuilder'
 
 describe('ContainerBuilder', () => {
   it('registers default dependencies', () => {
@@ -39,7 +40,7 @@ describe('ContainerBuilder', () => {
     providers.forEach(p => p.assert(container.resolve(p.token as Token<unknown>)))
 
     const providerContainer = new Container()
-    builder['registerProviders'](providerContainer)
+    new ProvidersBuilder('/data').register(providerContainer)
     const registeredTokens = Array.from(
       (providerContainer as unknown as { providers: Map<Token<unknown>, unknown> }).providers.keys()
     )

--- a/tests/engine/coreBuilder.test.ts
+++ b/tests/engine/coreBuilder.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import { CoreBuilder } from '@builders/coreBuilder'
+import { engineInitializerToken } from '@engine/engineInitializer'
+import { gameEngineToken } from '@engine/gameEngine'
+import { turnSchedulerToken } from '@engine/turnScheduler'
+import { keyboardeventListenerToken } from '@utils/keyboardEventListener'
+import { messageBusToken } from '@utils/messageBus'
+import { messageQueueToken } from '@utils/messageQueue'
+import { Container } from '@ioc/container'
+import type { Token } from '@ioc/token'
+
+describe('coreBuilder', () => {
+  it('registers core services', () => {
+    const builder = new CoreBuilder(() => () => {})
+    const container = new Container()
+    builder.register(container)
+
+    const registeredTokens = Array.from(
+      (container as unknown as { providers: Map<Token<unknown>, unknown> }).providers.keys()
+    )
+    expect(new Set(registeredTokens)).toEqual(
+      new Set([
+        gameEngineToken,
+        messageBusToken,
+        messageQueueToken,
+        turnSchedulerToken,
+        engineInitializerToken,
+        keyboardeventListenerToken,
+      ])
+    )
+  })
+})
+

--- a/tests/engine/loaderBuilder.test.ts
+++ b/tests/engine/loaderBuilder.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { LoadersBuilder } from '@builders/loadersBuilder'
+import { actionHandlersLoaderToken } from '@loader/actionHandlersLoader'
+import { gameLoaderToken } from '@loader/gameLoader'
+import { gameMapLoaderToken } from '@loader/gameMapLoader'
+import { languageLoaderToken } from '@loader/languageLoader'
+import { pageLoaderToken } from '@loader/pageLoader'
+import { tileSetLoaderToken } from '@loader/tileSetLoader'
+import { virtualInputsLoaderToken } from '@loader/virtualInputsLoader'
+import { virtualKeysLoaderToken } from '@loader/virtualKeysLoader'
+import { Container } from '@ioc/container'
+import type { Token } from '@ioc/token'
+
+describe('loadersBuilder', () => {
+  it('registers loaders', () => {
+    const builder = new LoadersBuilder()
+    const container = new Container()
+    builder.register(container)
+
+    const registeredTokens = Array.from(
+      (container as unknown as { providers: Map<Token<unknown>, unknown> }).providers.keys()
+    )
+    expect(new Set(registeredTokens)).toEqual(
+      new Set([
+        gameLoaderToken,
+        languageLoaderToken,
+        pageLoaderToken,
+        actionHandlersLoaderToken,
+        gameMapLoaderToken,
+        tileSetLoaderToken,
+        virtualKeysLoaderToken,
+        virtualInputsLoaderToken,
+      ])
+    )
+  })
+})
+

--- a/tests/engine/managerBuilder.test.ts
+++ b/tests/engine/managerBuilder.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { ManagersBuilder } from '@builders/managersBuilder'
+import { actionManagerToken } from '@managers/actionManager'
+import { domManagerToken } from '@managers/domManager'
+import { languageManagerToken } from '@managers/languageManager'
+import { mapManagerToken } from '@managers/mapManager'
+import { pageManagerToken } from '@managers/pageManager'
+import { Container } from '@ioc/container'
+import type { Token } from '@ioc/token'
+
+describe('managersBuilder', () => {
+  it('registers managers', () => {
+    const builder = new ManagersBuilder()
+    const container = new Container()
+    builder.register(container)
+
+    const registeredTokens = Array.from(
+      (container as unknown as { providers: Map<Token<unknown>, unknown> }).providers.keys()
+    )
+    expect(new Set(registeredTokens)).toEqual(
+      new Set([
+        domManagerToken,
+        languageManagerToken,
+        pageManagerToken,
+        actionManagerToken,
+        mapManagerToken,
+      ])
+    )
+  })
+})
+


### PR DESCRIPTION
## Summary
- split ContainerBuilder into dedicated sub-builders for core services, providers, loaders, registries, managers, and actions
- delegate container construction to these sub-builders for easier extension
- add unit tests covering the new builders

## Testing
- `npm run lint`
- `npm run build`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68a04371b6548332aefa1af559dade9e