### PR TITLE
refactor: extract map helpers

### DIFF
--- a/engine/builders/containerBuilder.ts
+++ b/engine/builders/containerBuilder.ts
@@ -47,6 +47,7 @@ export class ContainerBuilder implements IContainerBuilder {
     new LoadersBuilder().register(result)
     new ServicesBuilder().register(result)
     new RegistriesBuilder().register(result)
+    // Registers managers including map, tile set and player position managers
     new ManagersBuilder().register(result)
     new ActionsBuilder().register(result)
     // Hook for custom service registrations

--- a/engine/builders/managersBuilder.ts
+++ b/engine/builders/managersBuilder.ts
@@ -4,6 +4,8 @@ import { DomManager, domManagerDependencies, domManagerToken } from '@managers/d
 import { LanguageManager, languageManagerDependencies, languageManagerToken } from '@managers/languageManager'
 import { MapManager, mapManagerDependencies, mapManagerToken } from '@managers/mapManager'
 import { PageManager, pageManagerDependencies, pageManagerToken } from '@managers/pageManager'
+import { TileSetManager, tileSetManagerDependencies, tileSetManagerToken } from '@managers/tileSetManager'
+import { PlayerPositionManager, playerPositionManagerDependencies, playerPositionManagerToken } from '@managers/playerPositionManager'
 
 /**
  * Registers manager classes that orchestrate major engine systems.
@@ -33,6 +35,16 @@ export class ManagersBuilder {
       token: actionManagerToken,
       useClass: ActionManager,
       deps: actionManagerDependencies
+    })
+    container.register({
+      token: tileSetManagerToken,
+      useClass: TileSetManager,
+      deps: tileSetManagerDependencies
+    })
+    container.register({
+      token: playerPositionManagerToken,
+      useClass: PlayerPositionManager,
+      deps: playerPositionManagerDependencies
     })
     container.register({
       token: mapManagerToken,

--- a/engine/managers/mapManager.ts
+++ b/engine/managers/mapManager.ts
@@ -1,12 +1,13 @@
 import { Token, token } from '@ioc/token'
 import { Position } from '@loader/data/map'
 import { gameMapLoaderToken, IGameMapLoader } from '@loader/gameMapLoader'
-import { ITileSetLoader, tileSetLoaderToken } from '@loader/tileSetLoader'
 import { CHANGE_POSITION, MAP_SWITCHED, SWITCH_MAP } from '@messages/system'
 import { gameDataProviderToken, IGameDataProvider } from '@providers/gameDataProvider'
 import { fatalError } from '@utils/logMessage'
 import { IMessageBus, messageBusToken } from '@utils/messageBus'
 import { CleanUp } from '@utils/types'
+import { ITileSetManager, tileSetManagerToken } from './tileSetManager'
+import { IPlayerPositionManager, playerPositionManagerToken } from './playerPositionManager'
 
 /**
  * Coordinates loading and activation of maps within the game engine.
@@ -15,7 +16,6 @@ import { CleanUp } from '@utils/types'
  */
 export interface IMapManager {
     setActiveMap(mapId: string): Promise<void>
-    changePosition(position: Position): void
     initialize(): void
     cleanup(): void
 }
@@ -23,10 +23,11 @@ export interface IMapManager {
 const logName = 'MapManager'
 export const mapManagerToken = token<IMapManager>(logName)
 export const mapManagerDependencies: Token<unknown>[] = [
-    gameMapLoaderToken, 
+    gameMapLoaderToken,
     messageBusToken,
     gameDataProviderToken,
-    tileSetLoaderToken
+    tileSetManagerToken,
+    playerPositionManagerToken
 ]
 
 /**
@@ -40,7 +41,8 @@ export class MapManager implements IMapManager {
         private gameMapLoader: IGameMapLoader,
         private messageBus: IMessageBus,
         private gameDataProvider: IGameDataProvider,
-        private tileSetLoader: ITileSetLoader
+        private tileSetManager: ITileSetManager,
+        private playerPositionManager: IPlayerPositionManager
     ){}
 
     /**
@@ -75,21 +77,10 @@ export class MapManager implements IMapManager {
             this.messageBus.registerMessageListener(
                 CHANGE_POSITION,
                 message => {
-                    this.changePosition(message.payload as Position)
+                    this.playerPositionManager.changePosition(message.payload as Position)
                 }
             )
         ]
-    }
-
-    /**
-     * Updates the player's position within the current map.
-     *
-     * @param position - New coordinates for the player.
-     * @remarks Side effects: mutates the player's position in the game data
-     * provider's context.
-     */
-    public changePosition(position: Position): void {
-        this.gameDataProvider.Context.player.position = position
     }
 
     /**
@@ -108,7 +99,7 @@ export class MapManager implements IMapManager {
         if (this.gameDataProvider.Game.loadedMaps[mapId] === undefined){
             const map = await this.gameMapLoader.loadMap(path)
             this.gameDataProvider.Game.loadedMaps[mapId] = map
-            await this.ensureTileSets(map.tileSets)
+            await this.tileSetManager.ensureTileSets(map.tileSets)
         }
 
         this.gameDataProvider.Context.currentMapId = mapId
@@ -118,25 +109,4 @@ export class MapManager implements IMapManager {
         })
     }
 
-    /**
-     * Ensures that the provided tile sets are loaded into memory.
-     *
-     * @param tileSetIds - Identifiers of tile sets required by the map.
-     * @remarks Loads tile sets that have not been previously loaded and stores
-     * them in the game data provider.
-     */
-    public async ensureTileSets(tileSetIds: string[]): Promise<void> {
-        await Promise.all(
-            tileSetIds.map(async tileSetId => {
-                const path = this.gameDataProvider.Game.game.tiles[tileSetId]
-                if (!path) fatalError(logName, 'Tile set not found for id {0}', tileSetId)
-
-                if (!this.gameDataProvider.Game.loadedTileSets.has(tileSetId)) {
-                    const tileSet = await this.tileSetLoader.loadTileSet(path)
-                    this.gameDataProvider.Game.loadedTileSets.add(tileSetId)
-                    tileSet.tiles.forEach(tile => this.gameDataProvider.Game.loadedTiles.set(tile.key, tile))
-                }
-            })
-        )
-    }
 }

--- a/engine/managers/playerPositionManager.ts
+++ b/engine/managers/playerPositionManager.ts
@@ -1,0 +1,37 @@
+import { Token, token } from '@ioc/token'
+import { Position } from '@loader/data/map'
+import { gameDataProviderToken, IGameDataProvider } from '@providers/gameDataProvider'
+
+/**
+ * Manages player position updates.
+ */
+export interface IPlayerPositionManager {
+    changePosition(position: Position): void
+}
+
+const logName = 'PlayerPositionManager'
+export const playerPositionManagerToken = token<IPlayerPositionManager>(logName)
+export const playerPositionManagerDependencies: Token<unknown>[] = [
+    gameDataProviderToken
+]
+
+/**
+ * Default implementation of {@link IPlayerPositionManager}.
+ */
+export class PlayerPositionManager implements IPlayerPositionManager {
+    constructor(
+        private gameDataProvider: IGameDataProvider
+    ) {}
+
+    /**
+     * Updates the player's position within the current map.
+     *
+     * @param position - New coordinates for the player.
+     * @remarks Side effects: mutates the player's position in the game data
+     * provider's context.
+     */
+    public changePosition(position: Position): void {
+        this.gameDataProvider.Context.player.position = position
+    }
+}
+

--- a/engine/managers/tileSetManager.ts
+++ b/engine/managers/tileSetManager.ts
@@ -1,0 +1,51 @@
+import { Token, token } from '@ioc/token'
+import { ITileSetLoader, tileSetLoaderToken } from '@loader/tileSetLoader'
+import { fatalError } from '@utils/logMessage'
+import { gameDataProviderToken, IGameDataProvider } from '@providers/gameDataProvider'
+
+/**
+ * Handles loading of tile sets required by maps.
+ */
+export interface ITileSetManager {
+    ensureTileSets(tileSetIds: string[]): Promise<void>
+}
+
+const logName = 'TileSetManager'
+export const tileSetManagerToken = token<ITileSetManager>(logName)
+export const tileSetManagerDependencies: Token<unknown>[] = [
+    gameDataProviderToken,
+    tileSetLoaderToken
+]
+
+/**
+ * Default implementation of {@link ITileSetManager}.
+ */
+export class TileSetManager implements ITileSetManager {
+    constructor(
+        private gameDataProvider: IGameDataProvider,
+        private tileSetLoader: ITileSetLoader
+    ) {}
+
+    /**
+     * Ensures that the provided tile sets are loaded into memory.
+     *
+     * @param tileSetIds - Identifiers of tile sets required by the map.
+     * @remarks Loads tile sets that have not been previously loaded and stores
+     * them in the game data provider.
+     */
+    public async ensureTileSets(tileSetIds: string[]): Promise<void> {
+        await Promise.all(
+            tileSetIds.map(async tileSetId => {
+                const path = this.gameDataProvider.Game.game.tiles[tileSetId]
+                if (!path) fatalError(logName, 'Tile set not found for id {0}', tileSetId)
+
+                if (!this.gameDataProvider.Game.loadedTileSets.has(tileSetId)) {
+                    const tileSet = await this.tileSetLoader.loadTileSet(path)
+                    this.gameDataProvider.Game.loadedTileSets.add(tileSetId)
+                    tileSet.tiles.forEach(tile => this.gameDataProvider.Game.loadedTiles.set(tile.key, tile))
+                }
+            })
+        )
+    }
+}
+

--- a/tests/engine/containerBuilder.test.ts
+++ b/tests/engine/containerBuilder.test.ts
@@ -15,6 +15,9 @@ import { VirtualInputProvider, virtualInputProviderToken } from '@providers/virt
 import { Container } from '@ioc/container'
 import type { Token } from '@ioc/token'
 import { ProvidersBuilder } from '@builders/providersBuilder'
+import { MapManager, mapManagerToken } from '@managers/mapManager'
+import { TileSetManager, tileSetManagerToken } from '@managers/tileSetManager'
+import { PlayerPositionManager, playerPositionManagerToken } from '@managers/playerPositionManager'
 
 describe('ContainerBuilder', () => {
   it('registers default dependencies', () => {
@@ -24,10 +27,16 @@ describe('ContainerBuilder', () => {
     const bus = container.resolve(messageBusToken)
     const queue = container.resolve(messageQueueToken)
     const scheduler = container.resolve(turnSchedulerToken)
+    const mapManager = container.resolve(mapManagerToken)
+    const tileSetManager = container.resolve(tileSetManagerToken)
+    const playerPositionManager = container.resolve(playerPositionManagerToken)
     expect(engine).toBeInstanceOf(GameEngine)
     expect(bus).toBeInstanceOf(MessageBus)
     expect(queue).toBeInstanceOf(MessageQueue)
     expect(scheduler).toBeInstanceOf(TurnScheduler)
+    expect(mapManager).toBeInstanceOf(MapManager)
+    expect(tileSetManager).toBeInstanceOf(TileSetManager)
+    expect(playerPositionManager).toBeInstanceOf(PlayerPositionManager)
 
     const providers: { token: Token<unknown>, assert: (resolved: unknown) => void }[] = [
       { token: serviceProviderToken, assert: r => expect(r).toBeInstanceOf(ServiceProvider) },

--- a/tests/engine/managerBuilder.test.ts
+++ b/tests/engine/managerBuilder.test.ts
@@ -5,6 +5,8 @@ import { domManagerToken } from '@managers/domManager'
 import { languageManagerToken } from '@managers/languageManager'
 import { mapManagerToken } from '@managers/mapManager'
 import { pageManagerToken } from '@managers/pageManager'
+import { tileSetManagerToken } from '@managers/tileSetManager'
+import { playerPositionManagerToken } from '@managers/playerPositionManager'
 import { Container } from '@ioc/container'
 import type { Token } from '@ioc/token'
 
@@ -23,6 +25,8 @@ describe('managersBuilder', () => {
         languageManagerToken,
         pageManagerToken,
         actionManagerToken,
+        tileSetManagerToken,
+        playerPositionManagerToken,
         mapManagerToken,
       ])
     )

--- a/tests/engine/mapManager.test.ts
+++ b/tests/engine/mapManager.test.ts
@@ -3,78 +3,72 @@ import { MapManager } from '../../engine/managers/mapManager'
 import type { IGameMapLoader } from '../../engine/loader/gameMapLoader'
 import type { IMessageBus } from '../../utils/messageBus'
 import type { IGameDataProvider, GameData, GameContext } from '../../engine/providers/gameDataProvider'
-import type { ITileSetLoader } from '../../engine/loader/tileSetLoader'
+import type { ITileSetManager } from '../../engine/managers/tileSetManager'
+import type { IPlayerPositionManager } from '../../engine/managers/playerPositionManager'
+import { MAP_SWITCHED } from '../../engine/messages/system'
 
-function createManager(gameData: GameData, loadTileSet: ReturnType<typeof vi.fn>) {
-    const provider = {
-        get Game() { return gameData },
-        get Context() { return {} as GameContext },
-        initialize: vi.fn()
-    } as unknown as IGameDataProvider
-    const tileSetLoader = { loadTileSet } as unknown as ITileSetLoader
-    const mapLoader = {} as IGameMapLoader
-    const bus = {} as IMessageBus
-    return new MapManager(mapLoader, bus, provider, tileSetLoader)
+function createProvider(gameData: GameData, context: GameContext): IGameDataProvider {
+  return {
+    get Game() { return gameData },
+    get Context() { return context },
+    initialize: vi.fn()
+  } as unknown as IGameDataProvider
 }
 
-describe('MapManager.ensureTileSets', () => {
-    it('loads tile sets that are not yet loaded', async () => {
-        const gameData = {
-            game: { tiles: { ts1: 'ts1.json' } },
-            loadedTileSets: new Set<string>(),
-            loadedTiles: new Map()
-        } as unknown as GameData
-        const loadTileSet = vi.fn().mockResolvedValue({ id: 'ts1', tiles: [{ key: 'tile1' }] })
-        const manager = createManager(gameData, loadTileSet)
+describe('MapManager.setActiveMap', () => {
+  it('loads map and ensures tile sets', async () => {
+    const gameData = {
+      game: { maps: { m1: 'm1.json' } },
+      loadedMaps: {},
+      loadedTileSets: new Set<string>(),
+      loadedTiles: new Map()
+    } as unknown as GameData
+    const context = { currentMapId: null } as unknown as GameContext
+    const provider = createProvider(gameData, context)
+    const map = { tileSets: ['ts1'] }
+    const mapLoader = { loadMap: vi.fn().mockResolvedValue(map) } as unknown as IGameMapLoader
+    const ensureTileSets = vi.fn().mockResolvedValue(undefined)
+    const tileSetManager = { ensureTileSets } as unknown as ITileSetManager
+    const playerPositionManager = { changePosition: vi.fn() } as unknown as IPlayerPositionManager
+    const postMessage = vi.fn()
+    const messageBus = { registerMessageListener: vi.fn(), postMessage } as unknown as IMessageBus
 
-        await manager.ensureTileSets(['ts1'])
+    const manager = new MapManager(mapLoader, messageBus, provider, tileSetManager, playerPositionManager)
+    await manager.setActiveMap('m1')
 
-        expect(loadTileSet).toHaveBeenCalledWith('ts1.json')
-        expect(gameData.loadedTileSets.has('ts1')).toBe(true)
-        expect(gameData.loadedTiles.get('tile1')).toEqual({ key: 'tile1' })
-    })
-
-    it('does not reload tile sets that are already loaded', async () => {
-        const gameData = {
-            game: { tiles: { ts1: 'ts1.json' } },
-            loadedTileSets: new Set<string>(['ts1']),
-            loadedTiles: new Map([['tile1', { key: 'tile1' }]])
-        } as unknown as GameData
-        const loadTileSet = vi.fn().mockResolvedValue({ id: 'ts1-new', tiles: [{ key: 'tile2' }] })
-        const manager = createManager(gameData, loadTileSet)
-
-        await manager.ensureTileSets(['ts1'])
-
-        expect(loadTileSet).not.toHaveBeenCalled()
-        expect(gameData.loadedTileSets.has('ts1')).toBe(true)
-        expect(gameData.loadedTiles.get('tile1')).toEqual({ key: 'tile1' })
-    })
+    expect(mapLoader.loadMap).toHaveBeenCalledWith('m1.json')
+    expect(ensureTileSets).toHaveBeenCalledWith(['ts1'])
+    expect(gameData.loadedMaps['m1']).toBe(map)
+    expect(context.currentMapId).toBe('m1')
+    expect(postMessage).toHaveBeenCalledWith({ message: MAP_SWITCHED, payload: 'm1' })
+  })
 })
 
 describe('MapManager.initialize', () => {
-    it('clears previous listeners on repeated initialization', () => {
-        const cleanup1 = vi.fn()
-        const cleanup2 = vi.fn()
-        const register = vi.fn()
-            .mockReturnValueOnce(cleanup1)
-            .mockReturnValueOnce(cleanup2)
-            .mockReturnValue(() => {})
-        const messageBus = {
-            registerMessageListener: register
-        } as unknown as IMessageBus
+  it('clears previous listeners on repeated initialization', () => {
+    const cleanup1 = vi.fn()
+    const cleanup2 = vi.fn()
+    const register = vi.fn()
+      .mockReturnValueOnce(cleanup1)
+      .mockReturnValueOnce(cleanup2)
+      .mockReturnValue(() => {})
+    const messageBus = {
+      registerMessageListener: register
+    } as unknown as IMessageBus
 
-        const manager = new MapManager(
-            {} as IGameMapLoader,
-            messageBus,
-            {} as IGameDataProvider,
-            {} as ITileSetLoader
-        )
+    const manager = new MapManager(
+      {} as IGameMapLoader,
+      messageBus,
+      {} as IGameDataProvider,
+      {} as ITileSetManager,
+      {} as IPlayerPositionManager
+    )
 
-        manager.initialize()
-        manager.initialize()
+    manager.initialize()
+    manager.initialize()
 
-        expect(cleanup1).toHaveBeenCalledTimes(1)
-        expect(cleanup2).toHaveBeenCalledTimes(1)
-        expect(register).toHaveBeenCalledTimes(4)
-    })
+    expect(cleanup1).toHaveBeenCalledTimes(1)
+    expect(cleanup2).toHaveBeenCalledTimes(1)
+    expect(register).toHaveBeenCalledTimes(4)
+  })
 })

--- a/tests/engine/playerPositionManager.test.ts
+++ b/tests/engine/playerPositionManager.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from 'vitest'
+import { PlayerPositionManager } from '../../engine/managers/playerPositionManager'
+import type { IGameDataProvider, GameData, GameContext } from '../../engine/providers/gameDataProvider'
+import type { Position } from '../../engine/loader/data/map'
+
+function createManager(context: GameContext) {
+  const provider = {
+    get Game() { return {} as GameData },
+    get Context() { return context },
+    initialize: vi.fn(),
+  } as unknown as IGameDataProvider
+  return new PlayerPositionManager(provider)
+}
+
+describe('PlayerPositionManager.changePosition', () => {
+  it('updates player position in context', () => {
+    const context = { player: { position: { x: 0, y: 0 } } } as unknown as GameContext
+    const manager = createManager(context)
+    const newPos: Position = { x: 5, y: 7 }
+
+    manager.changePosition(newPos)
+
+    expect(context.player.position).toEqual(newPos)
+  })
+})

--- a/tests/engine/tileSetManager.test.ts
+++ b/tests/engine/tileSetManager.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from 'vitest'
+import { TileSetManager } from '../../engine/managers/tileSetManager'
+import type { IGameDataProvider, GameData, GameContext } from '../../engine/providers/gameDataProvider'
+import type { ITileSetLoader } from '../../engine/loader/tileSetLoader'
+
+function createManager(gameData: GameData, loadTileSet: ReturnType<typeof vi.fn>) {
+  const provider = {
+    get Game() { return gameData },
+    get Context() { return {} as GameContext },
+    initialize: vi.fn(),
+  } as unknown as IGameDataProvider
+  const tileSetLoader = { loadTileSet } as unknown as ITileSetLoader
+  return new TileSetManager(provider, tileSetLoader)
+}
+
+describe('TileSetManager.ensureTileSets', () => {
+  it('loads tile sets that are not yet loaded', async () => {
+    const gameData = {
+      game: { tiles: { ts1: 'ts1.json' } },
+      loadedTileSets: new Set<string>(),
+      loadedTiles: new Map(),
+    } as unknown as GameData
+    const loadTileSet = vi.fn().mockResolvedValue({ id: 'ts1', tiles: [{ key: 'tile1' }] })
+    const manager = createManager(gameData, loadTileSet)
+
+    await manager.ensureTileSets(['ts1'])
+
+    expect(loadTileSet).toHaveBeenCalledWith('ts1.json')
+    expect(gameData.loadedTileSets.has('ts1')).toBe(true)
+    expect(gameData.loadedTiles.get('tile1')).toEqual({ key: 'tile1' })
+  })
+
+  it('does not reload tile sets that are already loaded', async () => {
+    const gameData = {
+      game: { tiles: { ts1: 'ts1.json' } },
+      loadedTileSets: new Set<string>(['ts1']),
+      loadedTiles: new Map([['tile1', { key: 'tile1' }]]),
+    } as unknown as GameData
+    const loadTileSet = vi.fn().mockResolvedValue({ id: 'ts1-new', tiles: [{ key: 'tile2' }] })
+    const manager = createManager(gameData, loadTileSet)
+
+    await manager.ensureTileSets(['ts1'])
+
+    expect(loadTileSet).not.toHaveBeenCalled()
+    expect(gameData.loadedTileSets.has('ts1')).toBe(true)
+    expect(gameData.loadedTiles.get('tile1')).toEqual({ key: 'tile1' })
+  })
+})


### PR DESCRIPTION
## Summary
- add TileSetManager to centralize tile set loading
- add PlayerPositionManager to manage player location
- refactor MapManager to delegate tile-set and position responsibilities
- wire new managers into the DI container and builders
- test TileSetManager and PlayerPositionManager and update existing manager tests

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a045cf2bb88332b88035fa22e0676e