### PR TITLE
feat: add injectable logger

### DIFF
--- a/engine/app/controls/component/component.tsx
+++ b/engine/app/controls/component/component.tsx
@@ -1,5 +1,5 @@
 import { Component as ComponentData } from '@loader/data/component'
-import { logWarning } from '@utils/logMessage'
+import { loggerToken, type ILogger } from '@utils/logger'
 import { IComponentRegistry, componentRegistryToken } from '@registries/componentRegistry'
 import { useService } from '@app/iocProvider'
 
@@ -13,7 +13,8 @@ interface ComponentProps {
  * @param component - Definition of the unknown component.
  */
 const DefaultComponent: React.FC<ComponentProps> = ({ component }): React.JSX.Element => {
-    logWarning('Component', 'Unknown component type: {0}', component.type)
+    const logger = useService<ILogger>(loggerToken)
+    logger.warn('Component', 'Unknown component type: {0}', component.type)
     return (
         <div>Unsupported component type: {component.type}</div>
     )

--- a/engine/app/controls/screen/screen.tsx
+++ b/engine/app/controls/screen/screen.tsx
@@ -1,6 +1,7 @@
 import { Screen as ScreenData } from '@loader/data/page'
 import { Grid } from './grid'
-import { logWarning } from '@utils/logMessage'
+import { loggerToken, type ILogger } from '@utils/logger'
+import { useService } from '@app/iocProvider'
 
 interface ScreenProps {
     screen: ScreenData
@@ -14,13 +15,14 @@ const logName = 'Screen'
  * @param screen - Screen data to render.
  */
 export const Screen: React.FC<ScreenProps> = ({ screen }): React.JSX.Element | null => {
+    const logger = useService<ILogger>(loggerToken)
     switch (screen.type) {
         case 'grid':
             return (
                 <Grid screen={screen} />
             )
         default:
-            logWarning(logName, 'Unsupported screen type: {0}', screen.type)
+            logger.warn(logName, 'Unsupported screen type: {0}', screen.type)
             return null
     }
 }

--- a/engine/builders/containerBuilder.ts
+++ b/engine/builders/containerBuilder.ts
@@ -8,6 +8,7 @@ import { ManagersBuilder } from './managersBuilder'
 import { ProvidersBuilder } from './providersBuilder'
 import { RegistriesBuilder } from './registriesBuilder'
 import { ServicesBuilder } from './servicesBuilder'
+import { ConsoleLogger, loggerToken } from '@utils/logger'
 
 /**
  * Builder abstraction for creating and configuring a dependency injection container.
@@ -42,6 +43,7 @@ export class ContainerBuilder implements IContainerBuilder {
    */
   public build(): Container {
     const result = new Container()
+    result.register({ token: loggerToken, useClass: ConsoleLogger })
     new CoreBuilder(this.onQueueEmptyProvider).register(result)
     new ProvidersBuilder(this.dataPath).register(result)
     new LoadersBuilder().register(result)

--- a/engine/builders/coreBuilder.ts
+++ b/engine/builders/coreBuilder.ts
@@ -6,6 +6,7 @@ import type { Container as IContainer } from '@ioc/types'
 import { MessageBus, messageBusDependencies, messageBusToken } from '@utils/messageBus'
 import { MessageQueue, messageQueueToken } from '@utils/messageQueue'
 import { KeyboardEventListener, keyboardeventListenerDependencies, keyboardeventListenerToken } from '@utils/keyboardEventListener'
+import { loggerToken } from '@utils/logger'
 
 /**
  * Registers core engine services like the game engine and messaging infrastructure.
@@ -24,7 +25,7 @@ export class CoreBuilder {
     })
     container.register({
       token: messageQueueToken,
-      useFactory: c => new MessageQueue(this.onQueueEmptyProvider(c))
+      useFactory: c => new MessageQueue(this.onQueueEmptyProvider(c), c.resolve(loggerToken))
     })
     container.register({
       token: messageBusToken,

--- a/engine/builders/loadersBuilder.ts
+++ b/engine/builders/loadersBuilder.ts
@@ -1,13 +1,12 @@
 import { Container } from '@ioc/container'
 import { ActionHandlersLoader, actionHandlersLoaderDependencies, actionHandlersLoaderToken } from '@loader/actionHandlersLoader'
-import { GameLoader, gameLoaderToken } from '@loader/gameLoader'
+import { GameLoader, gameLoaderDependencies, gameLoaderToken } from '@loader/gameLoader'
 import { GameMapLoader, gameMapLoaderDependencies, gameMapLoaderToken } from '@loader/gameMapLoader'
 import { LanguageLoader, languageLoaderDependencies, languageLoaderToken } from '@loader/languageLoader'
 import { PageLoader, pageLoaderDependencies, pageLoaderToken } from '@loader/pageLoader'
 import { TileSetLoader, tileSetLoaderDependencies, tileSetLoaderToken } from '@loader/tileSetLoader'
 import { VirtualInputsLoader, virtualInputsLoaderDependencies, virtualInputsLoaderToken } from '@loader/virtualInputsLoader'
 import { VirtualKeysLoader, virtualKeysLoaderDependencies, virtualKeysLoaderToken } from '@loader/virtualKeysLoader'
-import { dataPathProviderToken } from '@providers/configProviders'
 
 /**
  * Registers loader components responsible for fetching game resources.
@@ -20,7 +19,7 @@ export class LoadersBuilder {
     container.register({
       token: gameLoaderToken,
       useClass: GameLoader,
-      deps: [dataPathProviderToken]
+      deps: gameLoaderDependencies
     })
     container.register({
       token: languageLoaderToken,

--- a/engine/builders/servicesBuilder.ts
+++ b/engine/builders/servicesBuilder.ts
@@ -1,5 +1,5 @@
 import { Container } from '@ioc/container'
-import { TranslationService, translationServiceToken } from '@services/translationService'
+import { TranslationService, translationServiceDependencies, translationServiceToken } from '@services/translationService'
 
 /**
  * Registers application level services.
@@ -12,7 +12,7 @@ export class ServicesBuilder {
     container.register({
       token: translationServiceToken,
       useClass: TranslationService,
-      deps: []
+      deps: translationServiceDependencies
     })
   }
 }

--- a/engine/engine/engineInitializer.ts
+++ b/engine/engine/engineInitializer.ts
@@ -5,7 +5,9 @@ import { domManagerToken, IDomManager } from '@managers/domManager'
 import { ILanguageManager, languageManagerToken } from '@managers/languageManager'
 import { gameDataProviderToken, IGameDataProvider } from '@providers/gameDataProvider'
 import { Game } from '@loader/data/game'
-import { fatalError, logDebug } from '@utils/logMessage'
+import { fatalError } from '@utils/logMessage'
+import type { ILogger } from '@utils/logger'
+import { loggerToken } from '@utils/logger'
 import { START_GAME_ENGINE_MESSAGE, SWITCH_PAGE } from '@messages/system'
 import { actionHandlerRegistryToken, IActionHandlerRegistry } from '@registries/actionHandlerRegistry'
 import { postMessageActionToken } from '@actions/postMessageAction'
@@ -40,7 +42,8 @@ export const engineInitializerDependencies: Token<unknown>[] = [
     actionManagerToken,
     mapManagerToken,
     virtualKeyProviderToken,
-    virtualInputProviderToken
+    virtualInputProviderToken,
+    loggerToken
 ]
 /**
  * Default {@link IEngineInitializer} implementation that orchestrates loading
@@ -70,7 +73,8 @@ export class EngineInitializer implements IEngineInitializer {
         private actionManager: IActionManager,
         private mapManager: IMapManager,
         private virtualKeyProvider: IVirtualKeyProvider,
-        private virtualInputProvider: IVirtualInputProvider
+        private virtualInputProvider: IVirtualInputProvider,
+        private logger: ILogger
     ){}
 
     /**
@@ -119,7 +123,7 @@ export class EngineInitializer implements IEngineInitializer {
         this.domManager.setTitle(game.title)
         game.cssFiles.forEach((cssFile: string) => {
             this.domManager.setCssFile(cssFile)
-            logDebug(logName, 'CSS file {0} set', cssFile)
+            this.logger.debug(logName, 'CSS file {0} set', cssFile)
         })
     }
 
@@ -132,7 +136,7 @@ export class EngineInitializer implements IEngineInitializer {
     private async loadGameDataRoot(): Promise<Game> {
         const game = await this.gameLoader.loadGame()
         if (!game) fatalError(logName, 'Game data is null or undefined')
-        logDebug(logName, 'Game loaded with data {0}', game)
+        this.logger.debug(logName, 'Game loaded with data {0}', game)
         return game
     }
 }

--- a/engine/engine/gameEngine.ts
+++ b/engine/engine/gameEngine.ts
@@ -1,6 +1,7 @@
 import { Token, token } from '@ioc/token'
 import { engineInitializerToken, IEngineInitializer } from './engineInitializer'
-import { logDebug } from '@utils/logMessage'
+import type { ILogger } from '@utils/logger'
+import { loggerToken } from '@utils/logger'
 
 
 /**
@@ -17,7 +18,7 @@ export interface IGameEngine {
 
 const logName: string = 'GameEngine'
 export const gameEngineToken = token<IGameEngine>(logName)
-export const gameEngineDependencies: Token<unknown>[] = [engineInitializerToken]
+export const gameEngineDependencies: Token<unknown>[] = [engineInitializerToken, loggerToken]
 
 /**
  * Concrete implementation of {@link IGameEngine} responsible for bootstrapping
@@ -30,7 +31,8 @@ export class GameEngine implements IGameEngine {
      * @param engineInitializer - Performs game initialization routines.
      */
     constructor(
-        private engineInitializer: IEngineInitializer
+        private engineInitializer: IEngineInitializer,
+        private logger: ILogger
     ) {
     }
 
@@ -40,7 +42,7 @@ export class GameEngine implements IGameEngine {
      * @returns A promise that resolves when the engine has fully started.
      */
     async start(): Promise<void> {
-        logDebug(logName, 'Starting game engine...')
+        this.logger.debug(logName, 'Starting game engine...')
         await this.engineInitializer.initialize()
     }
 }

--- a/engine/engine/turnScheduler.ts
+++ b/engine/engine/turnScheduler.ts
@@ -7,7 +7,8 @@
 import { Token, token } from '@ioc/token'
 import { IMessageBus, messageBusToken } from '@utils/messageBus'
 import { FINALIZE_END_TURN_MESSAGE, START_END_TURN_MESSAGE } from '@messages/system'
-import { logDebug } from '@utils/logMessage'
+import type { ILogger } from '@utils/logger'
+import { loggerToken } from '@utils/logger'
 
 
 export interface ITurnScheduler {
@@ -34,7 +35,7 @@ export type EndingTurnState = typeof EndingTurnState[keyof typeof EndingTurnStat
 
 const logName: string = 'TurnScheduler'
 export const turnSchedulerToken = token<ITurnScheduler>(logName)
-export const turnSchedulerDependencies: Token<unknown>[] = [messageBusToken]
+export const turnSchedulerDependencies: Token<unknown>[] = [messageBusToken, loggerToken]
 
 /**
  * Listens for empty message queues and progresses the game through the end of
@@ -49,7 +50,7 @@ export class TurnScheduler implements ITurnScheduler {
      * Creates a new scheduler wired to the provided message bus.
      * @param messageBus Bus used to post turn progression messages.
      */
-    constructor(private messageBus: IMessageBus) {
+    constructor(private messageBus: IMessageBus, private logger: ILogger) {
         this.endingTurn = EndingTurnState.NOT_STARTED
     }
 
@@ -76,7 +77,7 @@ export class TurnScheduler implements ITurnScheduler {
                 break
             case EndingTurnState.FINALIZING:
                 this.endingTurn = EndingTurnState.NOT_STARTED
-                logDebug(logName, 'Turn finalized')
+                this.logger.debug(logName, 'Turn finalized')
                 break
         }
     }

--- a/engine/loader/actionHandlersLoader.ts
+++ b/engine/loader/actionHandlersLoader.ts
@@ -3,6 +3,8 @@ import { type Handlers as HandlersData } from './data/handler'
 import { Handlers, handlersSchema } from './schema/handler'
 import { dataPathProviderToken, IDataPathProvider } from '@providers/configProviders'
 import { loadJsonResource } from '@utils/loadJsonResource'
+import type { ILogger } from '@utils/logger'
+import { loggerToken } from '@utils/logger'
 import { fatalError } from '@utils/logMessage'
 import { mapHandlers } from './mappers/handler'
 
@@ -23,7 +25,7 @@ export interface IActionHandlersLoader {
 
 const logName = 'ActionHandlersLoader'
 export const actionHandlersLoaderToken = token<IActionHandlersLoader>(logName)
-export const actionHandlersLoaderDependencies: Token<unknown>[] = [dataPathProviderToken]
+export const actionHandlersLoaderDependencies: Token<unknown>[] = [dataPathProviderToken, loggerToken]
 
 /**
  * Loads action handler definitions using a base path provider.
@@ -32,7 +34,7 @@ export class ActionHandlersLoader implements IActionHandlersLoader {
     /**
      * @param dataPathProvider Provides the base directory for handler data files.
      */
-    constructor(private dataPathProvider: IDataPathProvider) {
+    constructor(private dataPathProvider: IDataPathProvider, private logger: ILogger) {
     }
 
     /**
@@ -52,7 +54,8 @@ export class ActionHandlersLoader implements IActionHandlersLoader {
             paths.map(path =>
                 loadJsonResource<Handlers>(
                     `${this.dataPathProvider.dataPath}/${path}`,
-                    handlersSchema
+                    handlersSchema,
+                    this.logger
                 )
             )
         )

--- a/engine/loader/gameLoader.ts
+++ b/engine/loader/gameLoader.ts
@@ -4,6 +4,8 @@
  * representation for the engine to consume.
  */
 import { loadJsonResource } from '@utils/loadJsonResource'
+import type { ILogger } from '@utils/logger'
+import { loggerToken } from '@utils/logger'
 import { dataPathProviderToken, IDataPathProvider } from '@providers/configProviders'
 import { Game as GameData } from './data/game'
 import { Game, gameSchema } from './schema/game'
@@ -23,7 +25,7 @@ export interface IGameLoader {
 }
 
 export const gameLoaderToken = token<IGameLoader>('GameLoader')
-export const gameLoaderDependencies: Token<unknown>[] = [dataPathProviderToken]
+export const gameLoaderDependencies: Token<unknown>[] = [dataPathProviderToken, loggerToken]
 
 /**
  * Loads game data using a base path provided by {@link IDataPathProvider}.
@@ -33,7 +35,7 @@ export class GameLoader implements IGameLoader {
     /**
      * @param dataPathProvider Provides the base directory for game data files.
      */
-    constructor(private dataPathProvider: IDataPathProvider) {
+    constructor(private dataPathProvider: IDataPathProvider, private logger: ILogger) {
     }
 
     /**
@@ -42,7 +44,7 @@ export class GameLoader implements IGameLoader {
      * @returns The fully mapped {@link GameData} object.
      */
     async loadGame(): Promise<GameData> {
-        const game = await loadJsonResource<Game>(`${this.dataPathProvider.dataPath}/index.json`, gameSchema)
+        const game = await loadJsonResource<Game>(`${this.dataPathProvider.dataPath}/index.json`, gameSchema, this.logger)
         return mapGame(game, this.dataPathProvider.dataPath)
     }
 }

--- a/engine/loader/gameMapLoader.ts
+++ b/engine/loader/gameMapLoader.ts
@@ -7,6 +7,8 @@ import { Token, token } from '@ioc/token'
 import { type GameMap as GameMapData } from './data/map'
 import { dataPathProviderToken, IDataPathProvider } from '@providers/configProviders'
 import { loadJsonResource } from '@utils/loadJsonResource'
+import type { ILogger } from '@utils/logger'
+import { loggerToken } from '@utils/logger'
 import { GameMap, gameMapSchema } from './schema/map'
 import { mapGameMap } from './mappers/map'
 
@@ -25,7 +27,7 @@ export interface IGameMapLoader {
 
 const logName = 'GameMapLoader'
 export const gameMapLoaderToken = token<IGameMapLoader>(logName)
-export const gameMapLoaderDependencies: Token<unknown>[] = [dataPathProviderToken]
+export const gameMapLoaderDependencies: Token<unknown>[] = [dataPathProviderToken, loggerToken]
 /**
  * Retrieves map data using a base path provided by
  * {@link IDataPathProvider}.
@@ -34,7 +36,7 @@ export class GameMapLoader implements IGameMapLoader {
     /**
      * @param dataPathProvider Supplies the directory containing map resources.
      */
-    constructor(private dataPathProvider: IDataPathProvider) { }
+    constructor(private dataPathProvider: IDataPathProvider, private logger: ILogger) { }
 
     /**
      * Reads a map file, validates its structure and maps it into engine
@@ -44,7 +46,7 @@ export class GameMapLoader implements IGameMapLoader {
      * @returns The mapped {@link GameMapData} object.
      */
     public async loadMap(path: string): Promise<GameMapData> {
-        const schema = await loadJsonResource<GameMap>(`${this.dataPathProvider.dataPath}/${path}`, gameMapSchema)
+        const schema = await loadJsonResource<GameMap>(`${this.dataPathProvider.dataPath}/${path}`, gameMapSchema, this.logger)
         return mapGameMap(schema)
     }
 }

--- a/engine/loader/languageLoader.ts
+++ b/engine/loader/languageLoader.ts
@@ -7,6 +7,8 @@ import { dataPathProviderToken, IDataPathProvider } from '@providers/configProvi
 import { type Language as LanguageData } from './data/language'
 import { Language, languageSchema } from './schema/language'
 import { loadJsonResource } from '@utils/loadJsonResource'
+import type { ILogger } from '@utils/logger'
+import { loggerToken } from '@utils/logger'
 import { mapLanguage } from './mappers/language'
 import { fatalError } from '@utils/logMessage'
 
@@ -25,7 +27,7 @@ export interface ILanguageLoader {
 
 const logName = 'LanguageLoader'
 export const languageLoaderToken = token<ILanguageLoader>(logName)
-export const languageLoaderDependencies: Token<unknown>[] = [dataPathProviderToken]
+export const languageLoaderDependencies: Token<unknown>[] = [dataPathProviderToken, loggerToken]
 
 /**
  * Loads language data using a base path provided by {@link IDataPathProvider}.
@@ -34,7 +36,7 @@ export class LanguageLoader implements ILanguageLoader {
     /**
      * @param dataPathProvider Provides the base directory for language data files.
      */
-    constructor(private dataPathProvider: IDataPathProvider) {
+    constructor(private dataPathProvider: IDataPathProvider, private logger: ILogger) {
     }
 
     /**
@@ -50,7 +52,7 @@ export class LanguageLoader implements ILanguageLoader {
         }
 
         const schemas = await Promise.all(
-            paths.map(path => loadJsonResource<Language>(`${this.dataPathProvider.dataPath}/${path}`, languageSchema))
+            paths.map(path => loadJsonResource<Language>(`${this.dataPathProvider.dataPath}/${path}`, languageSchema, this.logger))
         )
         const languages = schemas.map(mapLanguage)
 

--- a/engine/loader/pageLoader.ts
+++ b/engine/loader/pageLoader.ts
@@ -6,6 +6,8 @@ import { Token, token } from '@ioc/token'
 import { type Page as PageData } from '@loader/data/page'
 import { dataPathProviderToken, IDataPathProvider } from '@providers/configProviders'
 import { loadJsonResource } from '@utils/loadJsonResource'
+import type { ILogger } from '@utils/logger'
+import { loggerToken } from '@utils/logger'
 import { Page, pageSchema } from './schema/page'
 import { mapPage } from './mappers/page'
 
@@ -23,7 +25,7 @@ export interface IPageLoader {
 }
 
 export const pageLoaderToken = token<IPageLoader>('PageLoader')
-export const pageLoaderDependencies: Token<unknown>[] = [dataPathProviderToken]
+export const pageLoaderDependencies: Token<unknown>[] = [dataPathProviderToken, loggerToken]
 
 /**
  * Loads page data using a base path provided by {@link IDataPathProvider}.
@@ -32,7 +34,7 @@ export class PageLoader implements IPageLoader {
     /**
      * @param dataPathProvider Provides the base directory for page data files.
      */
-    constructor(private dataPathProvider: IDataPathProvider) {}
+    constructor(private dataPathProvider: IDataPathProvider, private logger: ILogger) {}
 
     /**
      * Reads a page file, validates it and maps it into runtime data.
@@ -41,7 +43,7 @@ export class PageLoader implements IPageLoader {
      * @returns The fully mapped {@link PageData} object.
      */
     public async loadPage(path: string): Promise<PageData> {
-        const schema = await loadJsonResource<Page>(`${this.dataPathProvider.dataPath}/${path}`, pageSchema)
+        const schema = await loadJsonResource<Page>(`${this.dataPathProvider.dataPath}/${path}`, pageSchema, this.logger)
         return mapPage(this.dataPathProvider.dataPath, schema)
     }
 }

--- a/engine/loader/tileSetLoader.ts
+++ b/engine/loader/tileSetLoader.ts
@@ -7,6 +7,8 @@ import { type TileSet as TileSetData } from './data/tile'
 import { TileSet, tileSetSchema } from './schema/tile'
 import { dataPathProviderToken, IDataPathProvider } from '@providers/configProviders'
 import { loadJsonResource } from '@utils/loadJsonResource'
+import type { ILogger } from '@utils/logger'
+import { loggerToken } from '@utils/logger'
 import { mapTileSet } from './mappers/tile'
 
 /**
@@ -24,7 +26,7 @@ export interface ITileSetLoader {
 
 const logName = 'TileSetLoader'
 export const tileSetLoaderToken = token<ITileSetLoader>(logName)
-export const tileSetLoaderDependencies: Token<unknown>[] = [dataPathProviderToken]
+export const tileSetLoaderDependencies: Token<unknown>[] = [dataPathProviderToken, loggerToken]
 /**
  * Concrete implementation of {@link ITileSetLoader} that resolves files using
  * {@link IDataPathProvider}.
@@ -33,7 +35,7 @@ export class TileSetLoader implements ITileSetLoader {
     /**
      * @param dataPathProvider Provides the directory containing tileset files.
      */
-    constructor(private dataPathProvider: IDataPathProvider) { }
+    constructor(private dataPathProvider: IDataPathProvider, private logger: ILogger) { }
 
     /**
      * Loads a tileset file, validates its contents and maps it into engine
@@ -43,7 +45,7 @@ export class TileSetLoader implements ITileSetLoader {
      * @returns The mapped {@link TileSetData} object.
      */
     public async loadTileSet(path: string): Promise<TileSetData> {
-        const schema = await loadJsonResource<TileSet>(`${this.dataPathProvider.dataPath}/${path}`, tileSetSchema)
+        const schema = await loadJsonResource<TileSet>(`${this.dataPathProvider.dataPath}/${path}`, tileSetSchema, this.logger)
         return mapTileSet(this.dataPathProvider.dataPath, schema)
     }
 }

--- a/engine/loader/virtualInputsLoader.ts
+++ b/engine/loader/virtualInputsLoader.ts
@@ -3,6 +3,8 @@ import { type VirtualInputs as VirtualInputsData } from './data/inputs'
 import { dataPathProviderToken, IDataPathProvider } from '@providers/configProviders'
 import { fatalError } from '@utils/logMessage'
 import { loadJsonResource } from '@utils/loadJsonResource'
+import type { ILogger } from '@utils/logger'
+import { loggerToken } from '@utils/logger'
 import { VirtualInputs, virtualInputsSchema } from './schema/inputs'
 import { mapVirtualInputs } from './mappers/input'
 
@@ -23,7 +25,7 @@ export interface IVirtualInputsLoader {
 
 const logName = 'VirtualInputsLoader'
 export const virtualInputsLoaderToken = token<IVirtualInputsLoader>(logName)
-export const virtualInputsLoaderDependencies: Token<unknown>[] = [dataPathProviderToken]
+export const virtualInputsLoaderDependencies: Token<unknown>[] = [dataPathProviderToken, loggerToken]
 
 /**
  * Loads virtual input definitions using a base path provider.
@@ -34,7 +36,8 @@ export class VirtualInputsLoader implements IVirtualInputsLoader {
      * files.
      */
     constructor(
-        private dataPathProvider: IDataPathProvider
+        private dataPathProvider: IDataPathProvider,
+        private logger: ILogger
     ){}
 
     /**
@@ -51,7 +54,7 @@ export class VirtualInputsLoader implements IVirtualInputsLoader {
         }
 
         const schemas = await Promise.all(
-            paths.map(path => loadJsonResource<VirtualInputs>(`${this.dataPathProvider.dataPath}/${path}`, virtualInputsSchema))
+            paths.map(path => loadJsonResource<VirtualInputs>(`${this.dataPathProvider.dataPath}/${path}`, virtualInputsSchema, this.logger))
         )
 
         const result = schemas.reduce<VirtualInputsData>((acc, schema) => [...acc, ...mapVirtualInputs(schema)], [])

--- a/engine/loader/virtualKeysLoader.ts
+++ b/engine/loader/virtualKeysLoader.ts
@@ -4,6 +4,8 @@ import { dataPathProviderToken, IDataPathProvider } from '@providers/configProvi
 import { fatalError } from '@utils/logMessage'
 import { VirtualKeys, virtualKeysSchema } from './schema/inputs'
 import { loadJsonResource } from '@utils/loadJsonResource'
+import type { ILogger } from '@utils/logger'
+import { loggerToken } from '@utils/logger'
 import { mapVirtualKeys } from './mappers/input'
 
 /**
@@ -23,7 +25,7 @@ export interface IVirtualKeysLoader {
 
 const logName = 'VirtualKeysLoader'
 export const virtualKeysLoaderToken = token<IVirtualKeysLoader>(logName)
-export const virtualKeysLoaderDependencies: Token<unknown>[] = [dataPathProviderToken]
+export const virtualKeysLoaderDependencies: Token<unknown>[] = [dataPathProviderToken, loggerToken]
 
 /**
  * Loads virtual key definitions using a base path provider.
@@ -34,7 +36,8 @@ export class VirtualKeysLoader implements IVirtualKeysLoader {
      * files.
      */
     constructor(
-        private dataPathProvider: IDataPathProvider
+        private dataPathProvider: IDataPathProvider,
+        private logger: ILogger
     ) { }
 
     /**
@@ -51,7 +54,7 @@ export class VirtualKeysLoader implements IVirtualKeysLoader {
         }
 
         const schemas = await Promise.all(
-            paths.map(path => loadJsonResource<VirtualKeys>(`${this.dataPathProvider.dataPath}/${path}`, virtualKeysSchema))
+            paths.map(path => loadJsonResource<VirtualKeys>(`${this.dataPathProvider.dataPath}/${path}`, virtualKeysSchema, this.logger))
         )
 
         const result = schemas.reduce<VirtualKeysData>((acc, schema) => [...acc, ...mapVirtualKeys(schema)], [])

--- a/engine/managers/domManager.ts
+++ b/engine/managers/domManager.ts
@@ -4,7 +4,8 @@
  * should be routed through this manager to keep concerns centralized.
  */
 import { Token, token } from '@ioc/token'
-import { logWarning } from '@utils/logMessage'
+import type { ILogger } from '@utils/logger'
+import { loggerToken } from '@utils/logger'
 
 /**
  * Contract for components capable of manipulating the DOM.
@@ -27,7 +28,7 @@ export interface IDomManager {
 
 const logName = 'DomManager'
 export const domManagerToken = token<IDomManager>(logName)
-export const domManagerDependencies: Token<unknown>[] = []
+export const domManagerDependencies: Token<unknown>[] = [loggerToken]
 
 /**
  * Default implementation of {@link IDomManager} that targets the global
@@ -36,6 +37,7 @@ export const domManagerDependencies: Token<unknown>[] = []
 export class DomManager implements IDomManager {
     private writtenCssFiles: Set<string>
     private document?: Document
+    private logger: ILogger
 
     /**
      * Creates a new {@link DomManager}.
@@ -43,7 +45,8 @@ export class DomManager implements IDomManager {
      * @param doc - Optional `Document` to manipulate. If omitted, the global
      * `document` is used when running in a browser context.
      */
-    constructor(doc?: Document | null) {
+    constructor(logger: ILogger, doc?: Document | null) {
+        this.logger = logger
         if (doc !== undefined) {
             this.document = doc || undefined
         } else if (typeof document !== 'undefined') {
@@ -64,7 +67,7 @@ export class DomManager implements IDomManager {
 
         const head = this.document.head
         if (!head) {
-            logWarning(logName, 'Cannot append style {0}: head element is missing', path)
+            this.logger.warn(logName, 'Cannot append style {0}: head element is missing', path)
             return
         }
 

--- a/engine/registries/actionHandlerRegistry.ts
+++ b/engine/registries/actionHandlerRegistry.ts
@@ -2,7 +2,8 @@ import { Action, BaseAction } from '@loader/data/action'
 import { Message } from '@utils/types'
 import { token, type Token } from '@ioc/token'
 import { serviceProviderToken, type IServiceProvider } from '@providers/serviceProvider'
-import { logWarning } from '@utils/logMessage'
+import type { ILogger } from '@utils/logger'
+import { loggerToken } from '@utils/logger'
 
 /**
  * Represents a handler for a specific {@link Action} type.
@@ -40,11 +41,11 @@ export interface IActionHandlerRegistry {
 
 const logName = 'ActionHandlerRegistry'
 export const actionHandlerRegistryToken = token<IActionHandlerRegistry>(logName)
-export const actionHandlerRegistryDependencies: Token<unknown>[] = [serviceProviderToken]
+export const actionHandlerRegistryDependencies: Token<unknown>[] = [serviceProviderToken, loggerToken]
 export class ActionHandlerRegistry implements IActionHandlerRegistry {
     private readonly registry = new Map<string, Token<IActionHandler>>()
 
-    constructor(private serviceProvider: IServiceProvider) {}
+    constructor(private serviceProvider: IServiceProvider, private logger: ILogger) {}
 
     /**
      * Registers an action handler token for a given action type.
@@ -57,7 +58,7 @@ export class ActionHandlerRegistry implements IActionHandlerRegistry {
         handlerToken: Token<IActionHandler<T>>
     ): void {
         if (this.registry.has(type)) {
-            logWarning(logName, 'Handler already registered for action type {0}', type)
+            this.logger.warn(logName, 'Handler already registered for action type {0}', type)
             return
         }
         this.registry.set(type, handlerToken as Token<IActionHandler>)

--- a/engine/registries/componentRegistry.ts
+++ b/engine/registries/componentRegistry.ts
@@ -7,7 +7,8 @@
 import { GameMenuComponent } from '@app/controls/component/gameMenuComponent'
 import { ImageComponent } from '@app/controls/component/imageComponent'
 import { ComponentType } from 'react'
-import { logWarning } from '@utils/logMessage'
+import type { ILogger } from '@utils/logger'
+import { loggerToken } from '@utils/logger'
 import { token, Token } from '@ioc/token'
 import { SquaresMapComponent } from '@app/controls/component/squaresMapComponent'
 
@@ -20,12 +21,11 @@ export interface IComponentRegistry {
 const logName = 'ComponentRegistry'
 
 export const componentRegistryToken = token<IComponentRegistry>(logName)
-export const componentRegistryDependencies: Token<unknown>[] = []
+export const componentRegistryDependencies: Token<unknown>[] = [loggerToken]
 
 export class ComponentRegistry implements IComponentRegistry {
     private readonly registry = new Map<string, ComponentType<unknown>>()
-
-    constructor() {
+    constructor(private logger: ILogger) {
         this.registerComponent('image', ImageComponent)
         this.registerComponent('game-menu', GameMenuComponent)
         this.registerComponent('squares-map', SquaresMapComponent)
@@ -33,7 +33,7 @@ export class ComponentRegistry implements IComponentRegistry {
 
     public registerComponent<T = unknown>(type: string, component: ComponentType<T>): void {
         if (this.registry.has(type)) {
-            logWarning(logName, 'Component already registered under key {0}', type)
+            this.logger.warn(logName, 'Component already registered under key {0}', type)
             return
         }
         this.registry.set(type, component as ComponentType<unknown>)

--- a/engine/services/translationService.ts
+++ b/engine/services/translationService.ts
@@ -1,6 +1,8 @@
-import { token } from '@ioc/token'
+import { token, type Token } from '@ioc/token'
 import { Language } from '@loader/data/language'
-import { fatalError, logWarning } from '@utils/logMessage'
+import { fatalError } from '@utils/logMessage'
+import type { ILogger } from '@utils/logger'
+import { loggerToken } from '@utils/logger'
 
 /**
  * Exposes translation utilities for converting keys to localized strings.
@@ -26,14 +28,16 @@ export interface ITranslationService {
 
 const logName = 'TranslationService'
 export const translationServiceToken = token<ITranslationService>(logName)
+export const translationServiceDependencies: Token<unknown>[] = [loggerToken]
 
 /**
  * Service that resolves translation keys using provided {@link Language} data.
  * Must have a language configured before translation; otherwise `fatalError` is invoked.
- * If a key cannot be translated, `logWarning` is emitted and the key is returned.
+ * If a key cannot be translated, a warning is emitted and the key is returned.
  */
 export class TranslationService implements ITranslationService {
     private language: Language | null = null
+    constructor(private logger: ILogger) {}
 
     /**
      * Translates a key using the current language.
@@ -47,7 +51,7 @@ export class TranslationService implements ITranslationService {
         if (this.language === null) fatalError(logName, 'Language not set for translation')
         const translation = this.language.translations[key]
         if (translation === undefined) {
-            logWarning(logName, 'Missing translation for key {0}', key)
+            this.logger.warn(logName, 'Missing translation for key {0}', key)
             return key
         }
         return translation

--- a/tests/engine/actionHandlerRegistry.test.ts
+++ b/tests/engine/actionHandlerRegistry.test.ts
@@ -4,7 +4,8 @@ import { token } from '@ioc/token'
 import { Container } from '@ioc/container'
 import { IServiceProvider, ServiceProvider, serviceProviderToken } from '@providers/serviceProvider'
 import type { PostMessageAction } from '@loader/data/action'
-import * as log from '../../utils/logMessage'
+import type { ILogger } from '@utils/logger'
+import { loggerToken } from '@utils/logger'
 
 class TestHandler implements IActionHandler<PostMessageAction> {
     public readonly type = 'post-message'
@@ -26,6 +27,8 @@ describe('ActionHandlerRegistry', () => {
 
     beforeEach(() => {
         container = new Container()
+        const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+        container.register({ token: loggerToken, useValue: logger })
         container.register<IServiceProvider>({ token: serviceProviderToken, useFactory: c => new ServiceProvider(c) })
         container.register<IActionHandlerRegistry>({ token: actionHandlerRegistryToken, useClass: ActionHandlerRegistry, deps: actionHandlerRegistryDependencies })
         registry = container.resolve(actionHandlerRegistryToken)
@@ -51,15 +54,13 @@ describe('ActionHandlerRegistry', () => {
         const DUPLICATE = token<IActionHandler<PostMessageAction>>('duplicate')
         container.register({ token: HANDLER, useClass: TestHandler })
         container.register({ token: DUPLICATE, useClass: OtherHandler })
-        const warningSpy = vi.spyOn(log, 'logWarning')
+        const logger = container.resolve(loggerToken)
 
         registry.registerActionHandler('post-message', HANDLER)
         registry.registerActionHandler('post-message', DUPLICATE)
 
         const handler = registry.getActionHandler('post-message')
-        expect(warningSpy).toHaveBeenCalledTimes(1)
+        expect(logger.warn).toHaveBeenCalledTimes(1)
         expect(handler).toBeInstanceOf(TestHandler)
-
-        warningSpy.mockRestore()
     })
 })

--- a/tests/engine/actionHandlersLoader.test.ts
+++ b/tests/engine/actionHandlersLoader.test.ts
@@ -12,6 +12,7 @@ import { loadJsonResource } from '@utils/loadJsonResource'
 import { fatalError } from '@utils/logMessage'
 import { mapHandlers } from '@loader/mappers/handler'
 import { ActionHandlersLoader } from '@loader/actionHandlersLoader'
+import type { ILogger } from '@utils/logger'
 
 const dataPathProvider = { dataPath: '/base' }
 
@@ -30,18 +31,20 @@ describe('ActionHandlersLoader', () => {
       .mockReturnValueOnce([{ id: 1 }])
       .mockReturnValueOnce([{ id: 2 }])
 
-    const loader = new ActionHandlersLoader(dataPathProvider)
+    const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const loader = new ActionHandlersLoader(dataPathProvider, logger)
     const result = await loader.loadActions(['a.json', 'b.json'])
 
-    expect(loadJsonResource).toHaveBeenNthCalledWith(1, '/base/a.json', expect.anything())
-    expect(loadJsonResource).toHaveBeenNthCalledWith(2, '/base/b.json', expect.anything())
+    expect(loadJsonResource).toHaveBeenNthCalledWith(1, '/base/a.json', expect.anything(), logger)
+    expect(loadJsonResource).toHaveBeenNthCalledWith(2, '/base/b.json', expect.anything(), logger)
     expect(mapHandlers).toHaveBeenNthCalledWith(1, schema1)
     expect(mapHandlers).toHaveBeenNthCalledWith(2, schema2)
     expect(result).toEqual([{ id: 1 }, { id: 2 }])
   })
 
   it('throws when no handler paths provided', async () => {
-    const loader = new ActionHandlersLoader(dataPathProvider)
+    const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const loader = new ActionHandlersLoader(dataPathProvider, logger)
     await expect(loader.loadActions([])).rejects.toThrow('No action handlers paths provided')
   })
 
@@ -51,7 +54,8 @@ describe('ActionHandlersLoader', () => {
     })
     ;(loadJsonResource as unknown as Mock).mockImplementation(() => fatalError('fail'))
 
-    const loader = new ActionHandlersLoader(dataPathProvider)
+    const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const loader = new ActionHandlersLoader(dataPathProvider, logger)
     await expect(loader.loadActions(['a.json'])).rejects.toThrow('fatal')
 
     expect(fatalError).toHaveBeenCalled()
@@ -65,7 +69,8 @@ describe('ActionHandlersLoader', () => {
     })
     ;(mapHandlers as unknown as Mock).mockImplementation(() => fatalError('invalid'))
 
-    const loader = new ActionHandlersLoader(dataPathProvider)
+    const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const loader = new ActionHandlersLoader(dataPathProvider, logger)
     await expect(loader.loadActions(['a.json'])).rejects.toThrow('fatal')
 
     expect(fatalError).toHaveBeenCalled()

--- a/tests/engine/componentRegistry.test.ts
+++ b/tests/engine/componentRegistry.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { ComponentRegistry, componentRegistryToken, IComponentRegistry } from '@registries/componentRegistry'
-import * as log from '../../utils/logMessage'
+import type { ILogger } from '@utils/logger'
+import { loggerToken } from '@utils/logger'
 import { Container } from '@ioc/container'
 
 describe('ComponentRegistry', () => {
@@ -9,7 +10,9 @@ describe('ComponentRegistry', () => {
 
     beforeEach(() => {
         container = new Container()
-        container.register<IComponentRegistry>({ token: componentRegistryToken, useClass: ComponentRegistry })
+        const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+        container.register({ token: loggerToken, useValue: logger })
+        container.register<IComponentRegistry>({ token: componentRegistryToken, useClass: ComponentRegistry, deps: [loggerToken] })
         registry = container.resolve(componentRegistryToken)
         registry.clear()
     })
@@ -18,15 +21,13 @@ describe('ComponentRegistry', () => {
         const key = 'test-component'
         const original = () => null
         const duplicate = () => null
-        const warningSpy = vi.spyOn(log, 'logWarning')
+        const logger = container.resolve(loggerToken)
 
         registry.registerComponent(key, original)
         registry.registerComponent(key, duplicate)
 
-        expect(warningSpy).toHaveBeenCalledTimes(1)
+        expect(logger.warn).toHaveBeenCalledTimes(1)
         expect(registry.getComponent(key)).toBe(original)
-
-        warningSpy.mockRestore()
     })
 
     it('returns undefined when no component registered for type', () => {

--- a/tests/engine/domManager.test.ts
+++ b/tests/engine/domManager.test.ts
@@ -1,8 +1,9 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { DomManager } from '../../engine/managers/domManager'
+import type { ILogger } from '@utils/logger'
 
 describe('DomManager', () => {
   beforeEach(() => {
@@ -11,20 +12,22 @@ describe('DomManager', () => {
 
   it('avoids writing duplicate css links', () => {
     const path = '/style.css'
+    const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
 
-    const first = new DomManager()
+    const first = new DomManager(logger)
     first.setCssFile(path)
     first.setCssFile(path)
     expect(document.head.querySelectorAll(`link[href="${path}"]`).length).toBe(1)
 
-    const second = new DomManager()
+    const second = new DomManager(logger)
     second.setCssFile(path)
     expect(document.head.querySelectorAll(`link[href="${path}"]`).length).toBe(1)
   })
 
   it('does nothing when document is unavailable', () => {
     const path = '/style.css'
-    const manager = new DomManager(null)
+    const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const manager = new DomManager(logger, null)
     expect(() => manager.setCssFile(path)).not.toThrow()
     expect(() => manager.setTitle('test')).not.toThrow()
     expect(document.head.querySelectorAll(`link[href="${path}"]`).length).toBe(0)

--- a/tests/engine/engineInitializer.test.ts
+++ b/tests/engine/engineInitializer.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { EngineInitializer } from '../../engine/engine/engineInitializer'
+import type { ILogger } from '@utils/logger'
 import { START_GAME_ENGINE_MESSAGE, SWITCH_PAGE } from '../../engine/messages/system'
 import { postMessageActionToken } from '../../engine/actions/postMessageAction'
 import type { IMessageBus } from '../../utils/messageBus'
@@ -45,6 +46,7 @@ describe('EngineInitializer', () => {
     const virtualKeyProvider = { initialize: vi.fn() } as unknown as IVirtualKeyProvider
     const virtualInputProvider = { initialize: vi.fn() } as unknown as IVirtualInputProvider
 
+    const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
     const initializer = new EngineInitializer(
       messageBus,
       gameLoader,
@@ -56,7 +58,8 @@ describe('EngineInitializer', () => {
       actionManager,
       mapManager,
       virtualKeyProvider,
-      virtualInputProvider
+      virtualInputProvider,
+      logger
     )
 
     await initializer.initialize()

--- a/tests/engine/gameEngine.test.ts
+++ b/tests/engine/gameEngine.test.ts
@@ -1,12 +1,14 @@
 import { describe, it, expect, vi } from 'vitest'
 import { GameEngine } from '../../engine/engine/gameEngine'
 import type { IEngineInitializer } from '../../engine/engine/engineInitializer'
+import type { ILogger } from '@utils/logger'
 
 describe('GameEngine', () => {
   it('calls initializer once when started', async () => {
     const initialize = vi.fn()
     const initializer = { initialize } as unknown as IEngineInitializer
-    const engine = new GameEngine(initializer)
+    const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const engine = new GameEngine(initializer, logger)
 
     await engine.start()
 

--- a/tests/engine/gameLoader.test.ts
+++ b/tests/engine/gameLoader.test.ts
@@ -12,6 +12,7 @@ import { loadJsonResource } from '@utils/loadJsonResource'
 import { fatalError } from '@utils/logMessage'
 import { mapGame } from '@loader/mappers/game'
 import { GameLoader } from '@loader/gameLoader'
+import type { ILogger } from '@utils/logger'
 
 const dataPathProvider = { dataPath: '/base' }
 
@@ -26,10 +27,11 @@ describe('GameLoader', () => {
     const mapped = { mapped: true }
     ;(mapGame as unknown as Mock).mockReturnValue(mapped)
 
-    const loader = new GameLoader(dataPathProvider)
+    const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const loader = new GameLoader(dataPathProvider, logger)
     const result = await loader.loadGame()
 
-    expect(loadJsonResource).toHaveBeenCalledWith('/base/index.json', expect.anything())
+    expect(loadJsonResource).toHaveBeenCalledWith('/base/index.json', expect.anything(), logger)
     expect(mapGame).toHaveBeenCalledWith(schema, '/base')
     expect(result).toBe(mapped)
   })
@@ -40,7 +42,8 @@ describe('GameLoader', () => {
     })
     ;(loadJsonResource as unknown as Mock).mockImplementation(() => fatalError('fail'))
 
-    const loader = new GameLoader(dataPathProvider)
+    const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const loader = new GameLoader(dataPathProvider, logger)
     await expect(loader.loadGame()).rejects.toThrow('fatal')
 
     expect(fatalError).toHaveBeenCalled()
@@ -54,7 +57,8 @@ describe('GameLoader', () => {
     })
     ;(mapGame as unknown as Mock).mockImplementation(() => fatalError('invalid'))
 
-    const loader = new GameLoader(dataPathProvider)
+    const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const loader = new GameLoader(dataPathProvider, logger)
     await expect(loader.loadGame()).rejects.toThrow('fatal')
 
     expect(fatalError).toHaveBeenCalled()

--- a/tests/engine/languageLoader.test.ts
+++ b/tests/engine/languageLoader.test.ts
@@ -12,6 +12,7 @@ import { loadJsonResource } from '@utils/loadJsonResource'
 import { fatalError } from '@utils/logMessage'
 import { mapLanguage } from '@loader/mappers/language'
 import { LanguageLoader } from '@loader/languageLoader'
+import type { ILogger } from '@utils/logger'
 
 const dataPathProvider = { dataPath: '/base' }
 
@@ -30,11 +31,12 @@ describe('LanguageLoader', () => {
       .mockReturnValueOnce({ id: 'en', translations: { a: '1' } })
       .mockReturnValueOnce({ id: 'en', translations: { b: '2' } })
 
-    const loader = new LanguageLoader(dataPathProvider)
+    const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const loader = new LanguageLoader(dataPathProvider, logger)
     const result = await loader.loadLanguage(['lang/en.json', 'lang/en-extra.json'])
 
-    expect(loadJsonResource).toHaveBeenNthCalledWith(1, '/base/lang/en.json', expect.anything())
-    expect(loadJsonResource).toHaveBeenNthCalledWith(2, '/base/lang/en-extra.json', expect.anything())
+    expect(loadJsonResource).toHaveBeenNthCalledWith(1, '/base/lang/en.json', expect.anything(), logger)
+    expect(loadJsonResource).toHaveBeenNthCalledWith(2, '/base/lang/en-extra.json', expect.anything(), logger)
     const mock = mapLanguage as unknown as Mock
     expect(mock.mock.calls[0][0]).toBe(schema1)
     expect(mock.mock.calls[1][0]).toBe(schema2)
@@ -42,7 +44,8 @@ describe('LanguageLoader', () => {
   })
 
   it('throws when no language paths provided', async () => {
-    const loader = new LanguageLoader(dataPathProvider)
+    const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const loader = new LanguageLoader(dataPathProvider, logger)
     await expect(loader.loadLanguage([])).rejects.toThrow('No language paths provided')
   })
 
@@ -56,7 +59,8 @@ describe('LanguageLoader', () => {
       .mockReturnValueOnce({ id: 'en', translations: {} })
       .mockReturnValueOnce({ id: 'fr', translations: {} })
 
-    const loader = new LanguageLoader(dataPathProvider)
+    const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const loader = new LanguageLoader(dataPathProvider, logger)
     await expect(loader.loadLanguage(['a.json', 'b.json'])).rejects.toThrow(/Language ID mismatch/)
   })
 
@@ -66,7 +70,8 @@ describe('LanguageLoader', () => {
     })
     ;(loadJsonResource as unknown as Mock).mockImplementation(() => fatalError('fail'))
 
-    const loader = new LanguageLoader(dataPathProvider)
+    const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const loader = new LanguageLoader(dataPathProvider, logger)
     await expect(loader.loadLanguage(['a.json'])).rejects.toThrow('fatal')
 
     expect(fatalError).toHaveBeenCalled()
@@ -80,7 +85,8 @@ describe('LanguageLoader', () => {
     })
     ;(mapLanguage as unknown as Mock).mockImplementation(() => fatalError('invalid'))
 
-    const loader = new LanguageLoader(dataPathProvider)
+    const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const loader = new LanguageLoader(dataPathProvider, logger)
     await expect(loader.loadLanguage(['a.json'])).rejects.toThrow('fatal')
 
     expect(fatalError).toHaveBeenCalled()

--- a/tests/engine/languageManager.test.ts
+++ b/tests/engine/languageManager.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import { LanguageManager } from '../../engine/managers/languageManager'
 import { LanguageLoader, type ILanguageLoader } from '../../engine/loader/languageLoader'
+import type { ILogger } from '@utils/logger'
 import type { ITranslationService } from '../../engine/services/translationService'
 import type { IGameDataProvider, GameData, GameContext } from '../../engine/providers/gameDataProvider'
 import type { Language } from '@loader/data/language'
@@ -33,7 +34,8 @@ describe('LanguageManager', () => {
   })
 
   it('throws when language paths are empty', async () => {
-    const loader = new LanguageLoader({ dataPath: '' })
+    const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const loader = new LanguageLoader({ dataPath: '' }, logger)
     const translationService: ITranslationService = {
       translate: vi.fn(),
       setLanguage: vi.fn()

--- a/tests/engine/messageBus.test.ts
+++ b/tests/engine/messageBus.test.ts
@@ -2,11 +2,14 @@ import { describe, it, expect, vi } from 'vitest'
 import { MessageBus } from '@utils/messageBus'
 import { MessageQueue } from '@utils/messageQueue'
 import type { Message } from '@utils/types'
+import type { ILogger } from '@utils/logger'
 
 describe('MessageBus', () => {
   it('delivers posted messages to registered listeners', async () => {
-    const queue = new MessageQueue(() => {})
-    const bus = new MessageBus(queue)
+    const queueLogger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const busLogger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const queue = new MessageQueue(() => {}, queueLogger)
+    const bus = new MessageBus(queue, busLogger)
     const handler = vi.fn()
     bus.registerMessageListener('test', handler)
 
@@ -18,8 +21,10 @@ describe('MessageBus', () => {
   })
 
   it('unregistering listener prevents it from receiving messages', async () => {
-    const queue = new MessageQueue(() => {})
-    const bus = new MessageBus(queue)
+    const queueLogger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const busLogger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const queue = new MessageQueue(() => {}, queueLogger)
+    const bus = new MessageBus(queue, busLogger)
     const handler = vi.fn()
     const cleanup = bus.registerMessageListener('remove', handler)
     cleanup()
@@ -31,8 +36,10 @@ describe('MessageBus', () => {
   })
 
   it('queues messages when auto-drain is disabled and processes them when enabled', async () => {
-    const queue = new MessageQueue(() => {})
-    const bus = new MessageBus(queue)
+    const queueLogger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const busLogger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const queue = new MessageQueue(() => {}, queueLogger)
+    const bus = new MessageBus(queue, busLogger)
     const handled: Message[] = []
     bus.registerMessageListener('queued', m => {
       handled.push(m)
@@ -50,8 +57,10 @@ describe('MessageBus', () => {
   })
 
   it('removes map entry once all listeners are unregistered', () => {
-    const queue = new MessageQueue(() => {})
-    const bus = new MessageBus(queue)
+    const queueLogger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const busLogger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const queue = new MessageQueue(() => {}, queueLogger)
+    const bus = new MessageBus(queue, busLogger)
     const handler1 = vi.fn()
     const handler2 = vi.fn()
     const cleanup1 = bus.registerMessageListener('event', handler1)
@@ -68,8 +77,10 @@ describe('MessageBus', () => {
   })
 
   it('handles messages with diverse payload types', async () => {
-    const queue = new MessageQueue(() => {})
-    const bus = new MessageBus(queue)
+    const queueLogger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const busLogger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const queue = new MessageQueue(() => {}, queueLogger)
+    const bus = new MessageBus(queue, busLogger)
     const boolHandler = vi.fn()
     const arrayHandler = vi.fn()
     bus.registerMessageListener('bool', boolHandler)

--- a/tests/engine/messageQueue.test.ts
+++ b/tests/engine/messageQueue.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect, vi } from 'vitest'
 import { MessageQueue } from '@utils/messageQueue'
+import type { ILogger } from '@utils/logger'
 import type { Message } from '@utils/types'
 
 describe('MessageQueue', () => {
   it('processes messages and calls handler', async () => {
     const onEmpty = vi.fn()
-    const queue = new MessageQueue(onEmpty)
+    const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const queue = new MessageQueue(onEmpty, logger)
     const handled: Message[] = []
     queue.setHandler(m => {
       handled.push(m)
@@ -21,7 +23,8 @@ describe('MessageQueue', () => {
 
   it('processes queued messages after handler is set', async () => {
     const onEmpty = vi.fn()
-    const queue = new MessageQueue(onEmpty)
+    const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const queue = new MessageQueue(onEmpty, logger)
     const handled: Message[] = []
 
     queue.postMessage({ message: 'a', payload: null })
@@ -39,7 +42,8 @@ describe('MessageQueue', () => {
 
   it('queues messages when auto-drain disabled and drains when enabled', async () => {
     const onEmpty = vi.fn()
-    const queue = new MessageQueue(onEmpty)
+    const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const queue = new MessageQueue(onEmpty, logger)
     const handled: string[] = []
     queue.setHandler(m => {
       handled.push(m.message)
@@ -59,7 +63,8 @@ describe('MessageQueue', () => {
 
   it('drains queue manually and waits for async handlers', async () => {
     const onEmpty = vi.fn()
-    const queue = new MessageQueue(onEmpty)
+    const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const queue = new MessageQueue(onEmpty, logger)
     const order: string[] = []
     queue.setHandler(async m => {
       order.push(m.message)
@@ -77,7 +82,8 @@ describe('MessageQueue', () => {
 
   it('awaits thenable results', async () => {
     const onEmpty = vi.fn()
-    const queue = new MessageQueue(onEmpty)
+    const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const queue = new MessageQueue(onEmpty, logger)
     const order: string[] = []
     queue.setHandler(m => ({
       then: (resolve: () => void) => {
@@ -100,7 +106,8 @@ describe('MessageQueue', () => {
 
   it('reprocesses messages posted during draining before calling onQueueEmpty', async () => {
     const onEmpty = vi.fn()
-    const queue = new MessageQueue(onEmpty)
+    const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const queue = new MessageQueue(onEmpty, logger)
     const handled: string[] = []
     queue.setHandler(m => {
       handled.push(m.message)

--- a/tests/engine/pageLoader.test.ts
+++ b/tests/engine/pageLoader.test.ts
@@ -12,6 +12,7 @@ import { loadJsonResource } from '@utils/loadJsonResource'
 import { fatalError } from '@utils/logMessage'
 import { mapPage } from '@loader/mappers/page'
 import { PageLoader } from '@loader/pageLoader'
+import type { ILogger } from '@utils/logger'
 
 const dataPathProvider = { dataPath: '/base' }
 
@@ -26,10 +27,11 @@ describe('PageLoader', () => {
     const mapped = { id: 'page', content: [] }
     ;(mapPage as unknown as Mock).mockReturnValue(mapped)
 
-    const loader = new PageLoader(dataPathProvider)
+    const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const loader = new PageLoader(dataPathProvider, logger)
     const result = await loader.loadPage('pages/start.json')
 
-    expect(loadJsonResource).toHaveBeenCalledWith('/base/pages/start.json', expect.anything())
+    expect(loadJsonResource).toHaveBeenCalledWith('/base/pages/start.json', expect.anything(), logger)
     expect(mapPage).toHaveBeenCalledWith('/base', schema)
     expect(result).toBe(mapped)
   })
@@ -40,7 +42,8 @@ describe('PageLoader', () => {
     })
     ;(loadJsonResource as unknown as Mock).mockImplementation(() => fatalError('fail'))
 
-    const loader = new PageLoader(dataPathProvider)
+    const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const loader = new PageLoader(dataPathProvider, logger)
     await expect(loader.loadPage('pages/start.json')).rejects.toThrow('fatal')
 
     expect(fatalError).toHaveBeenCalled()
@@ -54,7 +57,8 @@ describe('PageLoader', () => {
     })
     ;(mapPage as unknown as Mock).mockImplementation(() => fatalError('invalid'))
 
-    const loader = new PageLoader(dataPathProvider)
+    const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const loader = new PageLoader(dataPathProvider, logger)
     await expect(loader.loadPage('pages/start.json')).rejects.toThrow('fatal')
 
     expect(fatalError).toHaveBeenCalled()

--- a/tests/engine/translationService.test.ts
+++ b/tests/engine/translationService.test.ts
@@ -1,21 +1,20 @@
 import { describe, it, expect, vi } from 'vitest'
 import { TranslationService } from '../../engine/services/translationService'
 import type { Language } from '@loader/data/language'
-import * as log from '../../utils/logMessage'
+import type { ILogger } from '@utils/logger'
 
 describe('TranslationService', () => {
   it('returns key when translation is missing and logs a warning', () => {
-    const warningSpy = vi.spyOn(log, 'logWarning')
-    const service = new TranslationService()
+    const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const service = new TranslationService(logger)
     const mockLanguage: Language = { id: 'en', translations: { existing: 'Hello' } }
     service.setLanguage(mockLanguage)
     expect(service.translate('missing')).toBe('missing')
-    expect(warningSpy).toHaveBeenCalledTimes(1)
-    warningSpy.mockRestore()
+    expect(logger.warn).toHaveBeenCalledTimes(1)
   })
 
   it('throws if language was not set', () => {
-    const service = new TranslationService()
+    const service = new TranslationService({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
     expect(() => service.translate('any')).toThrow('[TranslationService] Language not set for translation')
   })
 })

--- a/tests/engine/turnScheduler.test.ts
+++ b/tests/engine/turnScheduler.test.ts
@@ -2,12 +2,14 @@ import { describe, it, expect, vi } from 'vitest'
 import { TurnScheduler } from '../../engine/engine/turnScheduler'
 import { START_END_TURN_MESSAGE, FINALIZE_END_TURN_MESSAGE } from '../../engine/messages/system'
 import type { IMessageBus } from '../../utils/messageBus'
+import type { ILogger } from '@utils/logger'
 
 describe('TurnScheduler', () => {
   it('transitions state on successive empty queue events', () => {
     const postMessage = vi.fn()
     const bus = { postMessage } as unknown as IMessageBus
-    const scheduler = new TurnScheduler(bus)
+    const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const scheduler = new TurnScheduler(bus, logger)
 
     // first event: start ending turn
     scheduler.onQueueEmpty()

--- a/tests/engine/virtualInputsLoader.test.ts
+++ b/tests/engine/virtualInputsLoader.test.ts
@@ -6,6 +6,7 @@ vi.mock('@loader/mappers/input', () => ({ mapVirtualInputs: vi.fn() }))
 import { loadJsonResource } from '@utils/loadJsonResource'
 import { mapVirtualInputs } from '@loader/mappers/input'
 import { VirtualInputsLoader } from '@loader/virtualInputsLoader'
+import type { ILogger } from '@utils/logger'
 
 const dataPathProvider = { dataPath: '/base' }
 
@@ -24,11 +25,12 @@ describe('VirtualInputsLoader', () => {
       .mockReturnValueOnce([{ virtualInput: 'jump', virtualKeys: ['VK_JUMP'], label: 'Jump' }])
       .mockReturnValueOnce([{ virtualInput: 'run', virtualKeys: ['VK_RUN'], label: 'Run' }])
 
-    const loader = new VirtualInputsLoader(dataPathProvider)
+    const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const loader = new VirtualInputsLoader(dataPathProvider, logger)
     const result = await loader.loadVirtualInputs(['v1.json', 'v2.json'])
 
-    expect(loadJsonResource).toHaveBeenNthCalledWith(1, '/base/v1.json', expect.anything())
-    expect(loadJsonResource).toHaveBeenNthCalledWith(2, '/base/v2.json', expect.anything())
+    expect(loadJsonResource).toHaveBeenNthCalledWith(1, '/base/v1.json', expect.anything(), logger)
+    expect(loadJsonResource).toHaveBeenNthCalledWith(2, '/base/v2.json', expect.anything(), logger)
     expect(mapVirtualInputs).toHaveBeenNthCalledWith(1, schema1)
     expect(mapVirtualInputs).toHaveBeenNthCalledWith(2, schema2)
     expect(result).toEqual([
@@ -38,7 +40,8 @@ describe('VirtualInputsLoader', () => {
   })
 
   it('throws when no virtual inputs paths provided', async () => {
-    const loader = new VirtualInputsLoader(dataPathProvider)
+    const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const loader = new VirtualInputsLoader(dataPathProvider, logger)
     await expect(loader.loadVirtualInputs([])).rejects.toThrow('No virtual inputs paths provided')
   })
 })

--- a/tests/engine/virtualKeysLoader.test.ts
+++ b/tests/engine/virtualKeysLoader.test.ts
@@ -6,6 +6,7 @@ vi.mock('@loader/mappers/input', () => ({ mapVirtualKeys: vi.fn() }))
 import { loadJsonResource } from '@utils/loadJsonResource'
 import { mapVirtualKeys } from '@loader/mappers/input'
 import { VirtualKeysLoader } from '@loader/virtualKeysLoader'
+import type { ILogger } from '@utils/logger'
 
 const dataPathProvider = { dataPath: '/base' }
 
@@ -24,11 +25,12 @@ describe('VirtualKeysLoader', () => {
       .mockReturnValueOnce([{ virtualKey: 'jump', keyCode: 'Space', alt: false, ctrl: false, shift: false }])
       .mockReturnValueOnce([{ virtualKey: 'run', keyCode: 'KeyR', alt: false, ctrl: false, shift: false }])
 
-    const loader = new VirtualKeysLoader(dataPathProvider)
+    const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const loader = new VirtualKeysLoader(dataPathProvider, logger)
     const result = await loader.loadVirtualKeys(['k1.json', 'k2.json'])
 
-    expect(loadJsonResource).toHaveBeenNthCalledWith(1, '/base/k1.json', expect.anything())
-    expect(loadJsonResource).toHaveBeenNthCalledWith(2, '/base/k2.json', expect.anything())
+    expect(loadJsonResource).toHaveBeenNthCalledWith(1, '/base/k1.json', expect.anything(), logger)
+    expect(loadJsonResource).toHaveBeenNthCalledWith(2, '/base/k2.json', expect.anything(), logger)
     expect(mapVirtualKeys).toHaveBeenNthCalledWith(1, schema1)
     expect(mapVirtualKeys).toHaveBeenNthCalledWith(2, schema2)
     expect(result).toEqual([
@@ -38,7 +40,8 @@ describe('VirtualKeysLoader', () => {
   })
 
   it('throws when no virtual keys paths provided', async () => {
-    const loader = new VirtualKeysLoader(dataPathProvider)
+    const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const loader = new VirtualKeysLoader(dataPathProvider, logger)
     await expect(loader.loadVirtualKeys([])).rejects.toThrow('No virtual keys paths provided')
   })
 })

--- a/tests/utils/loadJsonResource.test.ts
+++ b/tests/utils/loadJsonResource.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, afterEach } from 'vitest'
 import { z } from 'zod'
 import { loadJsonResource } from '@utils/loadJsonResource'
 import * as log from '@utils/logMessage'
+import type { ILogger } from '@utils/logger'
 
 const originalFetch = globalThis.fetch
 
@@ -18,14 +19,16 @@ describe('loadJsonResource', () => {
             json: vi.fn().mockResolvedValue(data)
         } as unknown as Response))
         const schema = z.object({ id: z.string() })
-        await expect(loadJsonResource('/url', schema)).resolves.toEqual(data)
+        const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+        await expect(loadJsonResource('/url', schema, logger)).resolves.toEqual(data)
     })
 
     it('calls fatalError on network error', async () => {
         vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network')))
         const schema = z.object({ id: z.string() })
         const fatalSpy = vi.spyOn(log, 'fatalError').mockImplementation(() => { throw new Error('fatal') })
-        await expect(loadJsonResource('/url', schema)).rejects.toThrow('fatal')
+        const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+        await expect(loadJsonResource('/url', schema, logger)).rejects.toThrow('fatal')
         expect(fatalSpy).toHaveBeenCalled()
     })
 
@@ -33,7 +36,8 @@ describe('loadJsonResource', () => {
         vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false } as unknown as Response))
         const schema = z.object({ id: z.string() })
         const fatalSpy = vi.spyOn(log, 'fatalError').mockImplementation(() => { throw new Error('fatal') })
-        await expect(loadJsonResource('/url', schema)).rejects.toThrow('fatal')
+        const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+        await expect(loadJsonResource('/url', schema, logger)).rejects.toThrow('fatal')
         expect(fatalSpy).toHaveBeenCalled()
     })
 
@@ -44,7 +48,8 @@ describe('loadJsonResource', () => {
         } as unknown as Response))
         const schema = z.object({ id: z.string() })
         const fatalSpy = vi.spyOn(log, 'fatalError').mockImplementation(() => { throw new Error('fatal') })
-        await expect(loadJsonResource('/url', schema)).rejects.toThrow('fatal')
+        const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+        await expect(loadJsonResource('/url', schema, logger)).rejects.toThrow('fatal')
         expect(fatalSpy).toHaveBeenCalled()
     })
 
@@ -55,7 +60,8 @@ describe('loadJsonResource', () => {
         } as unknown as Response))
         const schema = z.object({ id: z.string() })
         const fatalSpy = vi.spyOn(log, 'fatalError').mockImplementation(() => { throw new Error('fatal') })
-        await expect(loadJsonResource('/url', schema)).rejects.toThrow('fatal')
+        const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+        await expect(loadJsonResource('/url', schema, logger)).rejects.toThrow('fatal')
         expect(fatalSpy).toHaveBeenCalled()
     })
 })

--- a/tests/utils/logMessage.test.ts
+++ b/tests/utils/logMessage.test.ts
@@ -11,8 +11,8 @@ describe('logMessage color reset', () => {
         vi.resetModules()
         process.env.LOG_LEVEL = 'debug'
         const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
-        const { logDebug } = await import('@utils/logMessage')
-        logDebug('test')
+        const { logMessage } = await import('@utils/logMessage')
+        logMessage(LogLevel.debug, undefined, 'test')
         expect(debugSpy).toHaveBeenCalledWith('\x1B[37mtest\x1B[0m')
     })
 
@@ -20,8 +20,8 @@ describe('logMessage color reset', () => {
         vi.resetModules()
         process.env.LOG_LEVEL = 'debug'
         const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {})
-        const { logInfo } = await import('@utils/logMessage')
-        logInfo('test')
+        const { logMessage } = await import('@utils/logMessage')
+        logMessage(LogLevel.info, undefined, 'test')
         expect(infoSpy).toHaveBeenCalledWith('\x1B[30mtest\x1B[0m')
     })
 
@@ -29,8 +29,8 @@ describe('logMessage color reset', () => {
         vi.resetModules()
         process.env.LOG_LEVEL = 'debug'
         const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-        const { logWarning } = await import('@utils/logMessage')
-        logWarning('test')
+        const { logMessage } = await import('@utils/logMessage')
+        logMessage(LogLevel.warning, undefined, 'test')
         expect(warnSpy).toHaveBeenCalledWith('\x1B[1m\x1B[33mtest\x1B[0m')
     })
 

--- a/tests/utils/messageBus.test.ts
+++ b/tests/utils/messageBus.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest'
 import { MessageBus } from '../../utils/messageBus'
 import type { IMessageQueue } from '../../utils/messageQueue'
 import type { Message } from '../../utils/types'
-import * as log from '../../utils/logMessage'
+import type { ILogger } from '../../utils/logger'
 
 class TestQueue implements IMessageQueue {
     private handler: ((message: Message) => void | Promise<void>) | null = null
@@ -20,28 +20,25 @@ class TestQueue implements IMessageQueue {
 
 describe('MessageBus notification messages', () => {
     let bus: MessageBus
+    let logger: ILogger
     beforeEach(() => {
         const queue = new TestQueue()
-        bus = new MessageBus(queue)
+        logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+        bus = new MessageBus(queue, logger)
         vi.restoreAllMocks()
     })
 
     it('unregisterNotificationMessage re-enables warnings', () => {
-        const debugSpy = vi.spyOn(log, 'logDebug')
-        const warningSpy = vi.spyOn(log, 'logWarning')
-
         bus.registerNotificationMessage('silent')
         bus.postMessage({ message: 'silent' })
+        expect(logger.debug).toHaveBeenCalledWith('MessageBus', 'No message listener for message: {0}', 'silent')
+        expect(logger.warn).not.toHaveBeenCalled()
 
-        expect(debugSpy).toHaveBeenCalledWith('MessageBus', 'No message listener for message: {0}', 'silent')
-        expect(warningSpy).not.toHaveBeenCalled()
-
-        debugSpy.mockClear()
-        warningSpy.mockClear()
+        ;(logger.debug as Mock).mockClear()
+        ;(logger.warn as Mock).mockClear()
 
         bus.unregisterNotificationMessage('silent')
         bus.postMessage({ message: 'silent' })
-
-        expect(warningSpy).toHaveBeenCalledWith('MessageBus', 'No message listener for message: {0}', 'silent')
+        expect(logger.warn).toHaveBeenCalledWith('MessageBus', 'No message listener for message: {0}', 'silent')
     })
 })

--- a/utils/README.md
+++ b/utils/README.md
@@ -4,4 +4,4 @@ A small collection of helper functions used across the engine.
 
 ## Available functions
 
-- **logMessage / logDebug / logInfo / logWarning / fatalError**: Utility logging helpers that format and output messages with a chosen log level.
+- **logMessage / fatalError**: Core logging helpers that format and output messages with a chosen log level. The `ConsoleLogger` class implements the `ILogger` interface to provide `debug`, `info`, `warn` and `error` methods.

--- a/utils/loadJsonResource.ts
+++ b/utils/loadJsonResource.ts
@@ -3,7 +3,8 @@
  * Emits debug logs and halts execution via {@link fatalError} on failure.
  */
 import { ZodType } from 'zod'
-import { fatalError, logDebug } from './logMessage'
+import { fatalError } from './logMessage'
+import type { ILogger } from './logger'
 
 const logName = 'loadJsonResource'
 
@@ -17,8 +18,8 @@ const logName = 'loadJsonResource'
  * JSON is invalid, or the data fails schema validation. Errors are reported via
  * {@link fatalError} which throws.
  */
-export async function loadJsonResource<T>(url: string, schema: ZodType<T>): Promise<T> {
-    logDebug(logName, 'Fetching JSON resource from {0}', url)
+export async function loadJsonResource<T>(url: string, schema: ZodType<T>, logger: ILogger): Promise<T> {
+    logger.debug(logName, 'Fetching JSON resource from {0}', url)
     let response: Response
     try {
         response = await fetch(url)
@@ -44,7 +45,7 @@ export async function loadJsonResource<T>(url: string, schema: ZodType<T>): Prom
         fatalError(logName, 'Schema validation failed for resource {0} with error {1}', url, parseResult.error.message)
     }
 
-    logDebug(logName, 'Resulting object: {0}', parseResult.data)
+    logger.debug(logName, 'Resulting object: {0}', parseResult.data)
 
     return parseResult.data
 }

--- a/utils/logMessage.ts
+++ b/utils/logMessage.ts
@@ -99,19 +99,6 @@ export function logMessage(
     return finalMessage
 }
 
-function createLogger(level: LogLevel) {
-    return (categoryOrMessage: string, messageOrArg?: unknown, ...args: unknown[]): string => {
-        if (typeof messageOrArg === 'string') {
-            return logMessage(level, categoryOrMessage, messageOrArg, ...args)
-        }
-        const params = messageOrArg === undefined ? args : [messageOrArg, ...args]
-        return logMessage(level, undefined, categoryOrMessage, ...params)
-    }
-}
-
-export const logDebug = createLogger(LogLevel.debug)
-export const logInfo = createLogger(LogLevel.info)
-export const logWarning = createLogger(LogLevel.warning)
 /**
  * Logs an error level message and immediately throws an {@link Error}.
  *

--- a/utils/logger.ts
+++ b/utils/logger.ts
@@ -1,0 +1,27 @@
+import { token } from '@ioc/token'
+import { LogLevel } from './types'
+import { logMessage } from './logMessage'
+
+export interface ILogger {
+    debug(category: string, message: string, ...args: unknown[]): string
+    info(category: string, message: string, ...args: unknown[]): string
+    warn(category: string, message: string, ...args: unknown[]): string
+    error(category: string, message: string, ...args: unknown[]): string
+}
+
+export const loggerToken = token<ILogger>('Logger')
+
+export class ConsoleLogger implements ILogger {
+    debug(category: string, message: string, ...args: unknown[]): string {
+        return logMessage(LogLevel.debug, category, message, ...args)
+    }
+    info(category: string, message: string, ...args: unknown[]): string {
+        return logMessage(LogLevel.info, category, message, ...args)
+    }
+    warn(category: string, message: string, ...args: unknown[]): string {
+        return logMessage(LogLevel.warning, category, message, ...args)
+    }
+    error(category: string, message: string, ...args: unknown[]): string {
+        return logMessage(LogLevel.error, category, message, ...args)
+    }
+}

--- a/utils/messageBus.ts
+++ b/utils/messageBus.ts
@@ -5,7 +5,8 @@
  * listeners in FIFO order.  The bus exposes a simple API to post messages,
  * subscribe to them and control queue processing.
  */
-import { logDebug, logWarning } from './logMessage'
+import type { ILogger } from './logger'
+import { loggerToken } from './logger'
 import type { CleanUp, Message } from './types'
 import { IMessageQueue, messageQueueToken } from './messageQueue'
 import { Token, token } from '@ioc/token'
@@ -60,7 +61,7 @@ export interface IMessageBus {
 
 const logName: string = 'MessageBus'
 export const messageBusToken = token<IMessageBus>(logName)
-export const messageBusDependencies: Token<unknown>[] = [messageQueueToken]
+export const messageBusDependencies: Token<unknown>[] = [messageQueueToken, loggerToken]
 /**
  * Default implementation of {@link IMessageBus} coordinating message dispatch
  * through an injected {@link IMessageQueue}.
@@ -70,13 +71,15 @@ export class MessageBus implements IMessageBus {
     private listeners: Map<string, MessageListener[]> = new Map<string, MessageListener[]>()
     private silentMessages: Set<string> = new Set<string>()
     private messageQueue: IMessageQueue
+    private logger: ILogger
 
     /**
      * Create a new message bus.
      * @param messageQueue - Queue used to schedule message processing.
      */
-    constructor(messageQueue: IMessageQueue) {
+    constructor(messageQueue: IMessageQueue, logger: ILogger) {
         this.messageQueue = messageQueue
+        this.logger = logger
         this.messageQueue.setHandler((message: Message<unknown>) => this.handleMessage(message))
     }
 
@@ -85,7 +88,7 @@ export class MessageBus implements IMessageBus {
      * @param message - Message to enqueue.
      */
     postMessage(message: Message<unknown>): void {
-        logDebug(logName, 'Push message: {0}', message)
+        this.logger.debug(logName, 'Push message: {0}', message)
         this.messageQueue.postMessage(message)
     }
 
@@ -150,8 +153,8 @@ export class MessageBus implements IMessageBus {
         const listeners = this.listeners.get(message.message)
         if (!listeners || listeners.length === 0) {
             const logger = this.silentMessages.has(message.message)
-                ? (msg: string, ...args: unknown[]) => logDebug(logName, msg, ...args)
-                : (msg: string, ...args: unknown[]) => logWarning(logName, msg, ...args)
+                ? (msg: string, ...args: unknown[]) => this.logger.debug(logName, msg, ...args)
+                : (msg: string, ...args: unknown[]) => this.logger.warn(logName, msg, ...args)
             logger('No message listener for message: {0}', message.message)
             return
         }
@@ -161,11 +164,11 @@ export class MessageBus implements IMessageBus {
                 const result = listener.handler(message)
                 if (result && typeof (result as Promise<void>).then === 'function') {
                     promises.push((result as Promise<void>).catch(err => {
-                        logWarning(logName, 'Error processing listener for message {0}: {1}', message.message, err)
+                        this.logger.warn(logName, 'Error processing listener for message {0}: {1}', message.message, err)
                     }))
                 }
             } catch (err) {
-                logWarning(logName, 'Error processing listener for message {0}: {1}', message.message, err)
+                this.logger.warn(logName, 'Error processing listener for message {0}: {1}', message.message, err)
             }
         })
         if (promises.length > 0) {
@@ -180,6 +183,6 @@ export class MessageBus implements IMessageBus {
         this.listeners.clear()
         this.silentMessages.clear()
         this.messageQueue.shutDown()
-        logDebug(logName, 'MessageBus shut down')
+        this.logger.debug(logName, 'MessageBus shut down')
     }
 }

--- a/utils/messageQueue.ts
+++ b/utils/messageQueue.ts
@@ -7,7 +7,7 @@
  */
 import { token } from '@ioc/token'
 import type { Message } from './types'
-import { logWarning } from './logMessage'
+import type { ILogger } from './logger'
 
 /**
  * Contract for message queues used by the {@link MessageBus}.
@@ -53,13 +53,15 @@ export class MessageQueue implements IMessageQueue {
     private emptyQueueAfterPost = 0
     private handler: ((message: Message) => void | Promise<void>) | null = null
     private readonly onQueueEmpty: () => void
+    private readonly logger: ILogger
 
     /**
      * Create a new message queue.
      * @param onQueueEmpty - Callback invoked after the queue has been fully drained.
      */
-    constructor(onQueueEmpty: () => void) {
+    constructor(onQueueEmpty: () => void, logger: ILogger) {
         this.onQueueEmpty = onQueueEmpty
+        this.logger = logger
     }
 
     /**
@@ -114,7 +116,7 @@ export class MessageQueue implements IMessageQueue {
                     try {
                         await result
                     } catch (err) {
-                        logWarning(logName, 'Error processing message {0}: {1}', message.message, err)
+                        this.logger.warn(logName, 'Error processing message {0}: {1}', message.message, err)
                     }
                 }
             }
@@ -127,7 +129,7 @@ export class MessageQueue implements IMessageQueue {
         try {
             this.onQueueEmpty()
         } catch (err) {
-            logWarning(logName, 'Error handling empty queue: {0}', err)
+            this.logger.warn(logName, 'Error handling empty queue: {0}', err)
         }
     }
 


### PR DESCRIPTION
## Summary
- introduce ILogger interface and ConsoleLogger implementation
- inject logger across engine and utility modules
- wire ConsoleLogger into the DI container

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68a0481c80988332a797598c25810a98