### PR TITLE
Refactor ActionExecuter to use injected logger

### DIFF
--- a/engine/actions/actionExecuter.ts
+++ b/engine/actions/actionExecuter.ts
@@ -1,7 +1,8 @@
 import { Token, token } from '@ioc/token'
 import { Action, BaseAction } from '@loader/data/action'
 import { ActionHandlerRegistry, actionHandlerRegistryToken } from '@registries/actionHandlerRegistry'
-import { fatalError } from '@utils/logMessage'
+import type { ILogger } from '@utils/logger'
+import { loggerToken } from '@utils/logger'
 import { Message } from '@utils/types'
 
 /**
@@ -14,14 +15,14 @@ export interface IActionExecuter {
      * @param action - The action to execute.
      * @param message - Optional message that triggered the action.
      * @param data - Additional data forwarded to the handler.
-     * @throws {@link fatalError} if no handler is registered for the action type.
+     * @throws Error if no handler is registered for the action type.
      */
     execute<T extends BaseAction = Action>(action: T, message?: Message, data?: unknown): void
 }
 
 const logName = 'ActionExecuter'
 export const actionExecuterToken = token<IActionExecuter>(logName)
-export const actionExecuterDependencies: Token<unknown>[] = [actionHandlerRegistryToken]
+export const actionExecuterDependencies: Token<unknown>[] = [actionHandlerRegistryToken, loggerToken]
 
 /**
  * Default implementation of {@link IActionExecuter} that delegates work to
@@ -32,8 +33,9 @@ export class ActionExecuter implements IActionExecuter {
      * Creates a new {@link ActionExecuter}.
      *
      * @param actionHandlerRegistry - Registry used to look up action handlers.
+     * @param logger - Logger used to report errors.
      */
-    constructor(private actionHandlerRegistry: ActionHandlerRegistry){}
+    constructor(private actionHandlerRegistry: ActionHandlerRegistry, private logger: ILogger){}
 
     /**
      * Executes the given action by invoking its associated handler.
@@ -41,11 +43,14 @@ export class ActionExecuter implements IActionExecuter {
      * @param action - Action instance to execute.
      * @param message - Optional message that led to the action.
      * @param data - Supplementary data passed to the handler.
-     * @throws {@link fatalError} if no handler exists for the action type.
+     * @throws Error if no handler exists for the action type.
      */
     public execute<T extends BaseAction = Action>(action: T, message?: Message, data?: unknown): void {
         const actionHandler = this.actionHandlerRegistry.getActionHandler(action.type)
-        if (!actionHandler) fatalError(logName, 'No action handler found for type {0}', action.type)
+        if (!actionHandler) {
+            this.logger.error(logName, 'No action handler found for type {0}', action.type)
+            throw new Error(`No action handler found for type ${action.type}`)
+        }
         actionHandler.handle(action, message, data)
     }
 }

--- a/tests/engine/actionExecuter.test.ts
+++ b/tests/engine/actionExecuter.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { ActionExecuter } from '@actions/actionExecuter'
 import type { BaseAction } from '@loader/data/action'
 import type { ActionHandlerRegistry } from '@registries/actionHandlerRegistry'
-import * as log from '../../utils/logMessage'
+import type { ILogger } from '@utils/logger'
 
 const KNOWN_TYPE = 'known-action'
 
@@ -10,13 +10,15 @@ describe('ActionExecuter', () => {
     let handler: { handle: ReturnType<typeof vi.fn> }
     let registry: ActionHandlerRegistry
     let executer: ActionExecuter
+    let logger: ILogger
 
     beforeEach(() => {
         handler = { handle: vi.fn() }
         registry = {
             getActionHandler: vi.fn((type: string) => (type === KNOWN_TYPE ? handler : undefined))
         } as unknown as ActionHandlerRegistry
-        executer = new ActionExecuter(registry)
+        logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+        executer = new ActionExecuter(registry, logger)
     })
 
     it('invokes handler when registered', () => {
@@ -25,12 +27,10 @@ describe('ActionExecuter', () => {
         expect(handler.handle).toHaveBeenCalledWith(action, undefined, undefined)
     })
 
-    it('triggers fatalError when handler missing', () => {
+    it('logs and throws when handler missing', () => {
         const action = { type: 'missing-action' } as BaseAction
-        const fatalErrorSpy = vi.spyOn(log, 'fatalError')
-        expect(() => executer.execute(action)).toThrow()
-        expect(fatalErrorSpy).toHaveBeenCalledWith('ActionExecuter', 'No action handler found for type {0}', 'missing-action')
-        fatalErrorSpy.mockRestore()
+        expect(() => executer.execute(action)).toThrow('No action handler found for type missing-action')
+        expect(logger.error).toHaveBeenCalledWith('ActionExecuter', 'No action handler found for type {0}', 'missing-action')
     })
 })
 


### PR DESCRIPTION
## Summary
- inject `ILogger` into `ActionExecuter` and register `loggerToken`
- log an error and throw when a handler is missing
- update tests for new error logging behavior

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a04d4afc18833280bcec8382143a6e