### PR TITLE
Inject logger into IoC container

### DIFF
--- a/engine/builders/containerBuilder.ts
+++ b/engine/builders/containerBuilder.ts
@@ -42,8 +42,9 @@ export class ContainerBuilder implements IContainerBuilder {
    * @remarks Mutates the new container by registering all engine services.
    */
   public build(): Container {
-    const result = new Container()
-    result.register({ token: loggerToken, useClass: ConsoleLogger })
+    const logger = new ConsoleLogger()
+    const result = new Container(logger)
+    result.register({ token: loggerToken, useValue: logger })
     new CoreBuilder(this.onQueueEmptyProvider).register(result)
     new ProvidersBuilder(this.dataPath).register(result)
     new LoadersBuilder().register(result)

--- a/engine/ioc/container.ts
+++ b/engine/ioc/container.ts
@@ -1,6 +1,6 @@
 import { describeToken, type Token } from './token'
 import type { Provider, Scope } from './types'
-import { fatalError } from '@utils/logMessage'
+import type { ILogger } from '@utils/logger'
 
 const logName: string = 'Container'
 
@@ -13,8 +13,12 @@ export class Container {
   private singletons = new Map<Token<unknown>, unknown>()
   private resolving: Token<unknown>[] = []
   readonly parent?: Container
+  private logger: ILogger
 
-  constructor(parent?: Container) { this.parent = parent }
+  constructor(logger: ILogger, parent?: Container) {
+    this.parent = parent
+    this.logger = logger
+  }
 
   /**
    * Registers a provider for the given token in the current container.
@@ -26,7 +30,7 @@ export class Container {
    */
   register<T>(provider: Provider<T>): this {
     if (this.providers.has(provider.token)) {
-      fatalError(logName, 'Provider for {0} already registered', describeToken(provider.token))
+      throw new Error(this.logger.error(logName, 'Provider for {0} already registered', describeToken(provider.token)))
     }
     this.providers.set(provider.token, provider)
     return this
@@ -36,7 +40,7 @@ export class Container {
    * Registers an array of providers.
    *
    * Each provider is passed to {@link register}. Registration halts on the
-   * first duplicate provider because {@link register} throws via `fatalError`.
+   * first duplicate provider because {@link register} throws an error.
    *
    * @param providers - Providers to be added to the container.
    * @returns The container instance for chaining.
@@ -63,7 +67,7 @@ export class Container {
    *
    * @returns A newly constructed child container.
    */
-  createChild(): Container { return new Container(this) }
+  createChild(): Container { return new Container(this.logger, this) }
 
   /**
    * Resolves an instance for the given token.
@@ -84,11 +88,13 @@ export class Container {
     if (this.singletons.has(t)) return this.singletons.get(t) as T
 
     const p = this.providers.get(t) ?? this.parent?.getProvider(t)
-    if (!p) fatalError(logName, 'No provider for {0}', describeToken(t))
+    if (!p) {
+      throw new Error(this.logger.error(logName, 'No provider for {0}', describeToken(t)))
+    }
 
     if (this.resolving.includes(t)) {
       const path = [...this.resolving, t].map(describeToken).join(' -> ')
-      fatalError(logName, 'Circular dependency detected: {0}', path)
+      throw new Error(this.logger.error(logName, 'Circular dependency detected: {0}', path))
     }
 
     this.resolving.push(t)
@@ -130,6 +136,6 @@ export class Container {
     }
     if ('useFactory' in p) return p.useFactory(this)
 
-    fatalError(logName, 'Invalid provider for {0}', describeToken((p as Provider<T>).token))
+    throw new Error(this.logger.error(logName, 'Invalid provider for {0}', describeToken((p as Provider<T>).token)))
   }
 }

--- a/tests/engine/actionHandlerRegistry.test.ts
+++ b/tests/engine/actionHandlerRegistry.test.ts
@@ -26,8 +26,14 @@ describe('ActionHandlerRegistry', () => {
     let container: Container
 
     beforeEach(() => {
-        container = new Container()
-        const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+        const logger: ILogger = {
+            debug: vi.fn(),
+            info: vi.fn(),
+            warn: vi.fn(),
+            error: vi.fn((category: string, message: string, ...args: unknown[]) =>
+                `[${category}] ${message.replace(/\{(\d+)\}/g, (_: string, i: string) => String(args[Number(i)]))}`),
+        }
+        container = new Container(logger)
         container.register({ token: loggerToken, useValue: logger })
         container.register<IServiceProvider>({ token: serviceProviderToken, useFactory: c => new ServiceProvider(c) })
         container.register<IActionHandlerRegistry>({ token: actionHandlerRegistryToken, useClass: ActionHandlerRegistry, deps: actionHandlerRegistryDependencies })

--- a/tests/engine/componentRegistry.test.ts
+++ b/tests/engine/componentRegistry.test.ts
@@ -9,8 +9,14 @@ describe('ComponentRegistry', () => {
     let container: Container
 
     beforeEach(() => {
-        container = new Container()
-        const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+        const logger: ILogger = {
+            debug: vi.fn(),
+            info: vi.fn(),
+            warn: vi.fn(),
+            error: vi.fn((category: string, message: string, ...args: unknown[]) =>
+                `[${category}] ${message.replace(/\{(\d+)\}/g, (_: string, i: string) => String(args[Number(i)]))}`),
+        }
+        container = new Container(logger)
         container.register({ token: loggerToken, useValue: logger })
         container.register<IComponentRegistry>({ token: componentRegistryToken, useClass: ComponentRegistry, deps: [loggerToken] })
         registry = container.resolve(componentRegistryToken)

--- a/tests/engine/configProviders.test.ts
+++ b/tests/engine/configProviders.test.ts
@@ -1,10 +1,18 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { Container } from '@ioc/container'
 import { dataPathProviderToken, type IDataPathProvider } from '@providers/configProviders'
+import type { ILogger } from '@utils/logger'
 
 describe('configProviders', () => {
   it('provides dataPath via the DI container', () => {
-    const container = new Container()
+    const logger: ILogger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn((category: string, message: string, ...args: unknown[]) =>
+        `[${category}] ${message.replace(/\{(\d+)\}/g, (_: string, i: string) => String(args[Number(i)]))}`),
+    }
+    const container = new Container(logger)
     const provider: IDataPathProvider = { dataPath: '/test/data' }
     container.register({ token: dataPathProviderToken, useValue: provider })
 
@@ -13,7 +21,14 @@ describe('configProviders', () => {
   })
 
   it('throws when dataPathProvider is not registered', () => {
-    const container = new Container()
+    const logger: ILogger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn((category: string, message: string, ...args: unknown[]) =>
+        `[${category}] ${message.replace(/\{(\d+)\}/g, (_: string, i: string) => String(args[Number(i)]))}`),
+    }
+    const container = new Container(logger)
     expect(() => container.resolve(dataPathProviderToken))
       .toThrowError('[Container] No provider for DataPathProvider')
   })

--- a/tests/engine/container.test.ts
+++ b/tests/engine/container.test.ts
@@ -1,6 +1,18 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { Container } from '@ioc/container'
 import { token } from '@ioc/token'
+import type { ILogger } from '@utils/logger'
+
+function makeContainer(): Container {
+  const logger: ILogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn((category: string, message: string, ...args: unknown[]) =>
+      `[${category}] ${message.replace(/\{(\d+)\}/g, (_: string, i: string) => String(args[Number(i)]))}`),
+  }
+  return new Container(logger)
+}
 
 describe('IoC Container', () => {
   it('resolves registered dependencies', () => {
@@ -14,7 +26,7 @@ describe('IoC Container', () => {
       }
     }
 
-    const c = new Container()
+    const c = makeContainer()
     c.register({ token: NUM, useValue: 42 })
     c.register({ token: DEP, useClass: Dep, deps: [NUM] })
 
@@ -27,13 +39,13 @@ describe('IoC Container', () => {
     class Foo {}
     const FOO = token<Foo>('foo')
 
-    const singletonContainer = new Container()
+    const singletonContainer = makeContainer()
     singletonContainer.register({ token: FOO, useClass: Foo })
     const s1 = singletonContainer.resolve(FOO)
     const s2 = singletonContainer.resolve(FOO)
     expect(s1).toBe(s2)
 
-    const transientContainer = new Container()
+    const transientContainer = makeContainer()
     transientContainer.register({ token: FOO, useClass: Foo, scope: 'transient' })
     const t1 = transientContainer.resolve(FOO)
     const t2 = transientContainer.resolve(FOO)
@@ -46,7 +58,7 @@ describe('IoC Container', () => {
     const A_TOKEN = token<A>('A')
     const B_TOKEN = token<B>('B')
 
-    const c = new Container()
+    const c = makeContainer()
     c.register({ token: A_TOKEN, useClass: A, deps: [B_TOKEN] })
     c.register({ token: B_TOKEN, useClass: B, deps: [A_TOKEN] })
 
@@ -55,7 +67,7 @@ describe('IoC Container', () => {
 
   it('throws and does not override when registering the same token twice', () => {
     const FOO = token<number>('foo')
-    const c = new Container()
+    const c = makeContainer()
     c.register({ token: FOO, useValue: 1 })
     expect(() => c.register({ token: FOO, useValue: 2 })).toThrowError(/already registered/)
     expect(c.resolve(FOO)).toBe(1)

--- a/tests/engine/containerBuilder.test.ts
+++ b/tests/engine/containerBuilder.test.ts
@@ -18,6 +18,7 @@ import { ProvidersBuilder } from '@builders/providersBuilder'
 import { MapManager, mapManagerToken } from '@managers/mapManager'
 import { TileSetManager, tileSetManagerToken } from '@managers/tileSetManager'
 import { PlayerPositionManager, playerPositionManagerToken } from '@managers/playerPositionManager'
+import type { ILogger } from '@utils/logger'
 
 describe('ContainerBuilder', () => {
   it('registers default dependencies', () => {
@@ -48,7 +49,14 @@ describe('ContainerBuilder', () => {
 
     providers.forEach(p => p.assert(container.resolve(p.token as Token<unknown>)))
 
-    const providerContainer = new Container()
+    const logger: ILogger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn((category: string, message: string, ...args: unknown[]) =>
+        `[${category}] ${message.replace(/\{(\d+)\}/g, (_: string, i: string) => String(args[Number(i)]))}`),
+    }
+    const providerContainer = new Container(logger)
     new ProvidersBuilder('/data').register(providerContainer)
     const registeredTokens = Array.from(
       (providerContainer as unknown as { providers: Map<Token<unknown>, unknown> }).providers.keys()

--- a/tests/engine/coreBuilder.test.ts
+++ b/tests/engine/coreBuilder.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { CoreBuilder } from '@builders/coreBuilder'
 import { engineInitializerToken } from '@engine/engineInitializer'
 import { gameEngineToken } from '@engine/gameEngine'
@@ -8,11 +8,19 @@ import { messageBusToken } from '@utils/messageBus'
 import { messageQueueToken } from '@utils/messageQueue'
 import { Container } from '@ioc/container'
 import type { Token } from '@ioc/token'
+import type { ILogger } from '@utils/logger'
 
 describe('coreBuilder', () => {
   it('registers core services', () => {
     const builder = new CoreBuilder(() => () => {})
-    const container = new Container()
+    const logger: ILogger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn((category: string, message: string, ...args: unknown[]) =>
+        `[${category}] ${message.replace(/\{(\d+)\}/g, (_: string, i: string) => String(args[Number(i)]))}`),
+    }
+    const container = new Container(logger)
     builder.register(container)
 
     const registeredTokens = Array.from(

--- a/tests/engine/loaderBuilder.test.ts
+++ b/tests/engine/loaderBuilder.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { LoadersBuilder } from '@builders/loadersBuilder'
 import { actionHandlersLoaderToken } from '@loader/actionHandlersLoader'
 import { gameLoaderToken } from '@loader/gameLoader'
@@ -10,11 +10,19 @@ import { virtualInputsLoaderToken } from '@loader/virtualInputsLoader'
 import { virtualKeysLoaderToken } from '@loader/virtualKeysLoader'
 import { Container } from '@ioc/container'
 import type { Token } from '@ioc/token'
+import type { ILogger } from '@utils/logger'
 
 describe('loadersBuilder', () => {
   it('registers loaders', () => {
     const builder = new LoadersBuilder()
-    const container = new Container()
+    const logger: ILogger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn((category: string, message: string, ...args: unknown[]) =>
+        `[${category}] ${message.replace(/\{(\d+)\}/g, (_: string, i: string) => String(args[Number(i)]))}`),
+    }
+    const container = new Container(logger)
     builder.register(container)
 
     const registeredTokens = Array.from(

--- a/tests/engine/managerBuilder.test.ts
+++ b/tests/engine/managerBuilder.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { ManagersBuilder } from '@builders/managersBuilder'
 import { actionManagerToken } from '@managers/actionManager'
 import { domManagerToken } from '@managers/domManager'
@@ -9,11 +9,19 @@ import { tileSetManagerToken } from '@managers/tileSetManager'
 import { playerPositionManagerToken } from '@managers/playerPositionManager'
 import { Container } from '@ioc/container'
 import type { Token } from '@ioc/token'
+import type { ILogger } from '@utils/logger'
 
 describe('managersBuilder', () => {
   it('registers managers', () => {
     const builder = new ManagersBuilder()
-    const container = new Container()
+    const logger: ILogger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn((category: string, message: string, ...args: unknown[]) =>
+        `[${category}] ${message.replace(/\{(\d+)\}/g, (_: string, i: string) => String(args[Number(i)]))}`),
+    }
+    const container = new Container(logger)
     builder.register(container)
 
     const registeredTokens = Array.from(


### PR DESCRIPTION
## Summary
- Inject `ILogger` into the IoC Container and log errors before throwing.
- Construct ContainerBuilder with a ConsoleLogger and register it for consumers.
- Update tests for new Container signature.

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68a04d727a008332804ee98e68957ecf