### PR TITLE
feat: inject logger into map manager

### DIFF
--- a/engine/managers/mapManager.ts
+++ b/engine/managers/mapManager.ts
@@ -3,7 +3,8 @@ import { Position } from '@loader/data/map'
 import { gameMapLoaderToken, IGameMapLoader } from '@loader/gameMapLoader'
 import { CHANGE_POSITION, MAP_SWITCHED, SWITCH_MAP } from '@messages/system'
 import { gameDataProviderToken, IGameDataProvider } from '@providers/gameDataProvider'
-import { fatalError } from '@utils/logMessage'
+import type { ILogger } from '@utils/logger'
+import { loggerToken } from '@utils/logger'
 import { IMessageBus, messageBusToken } from '@utils/messageBus'
 import { CleanUp } from '@utils/types'
 import { ITileSetManager, tileSetManagerToken } from './tileSetManager'
@@ -27,7 +28,8 @@ export const mapManagerDependencies: Token<unknown>[] = [
     messageBusToken,
     gameDataProviderToken,
     tileSetManagerToken,
-    playerPositionManagerToken
+    playerPositionManagerToken,
+    loggerToken
 ]
 
 /**
@@ -42,7 +44,8 @@ export class MapManager implements IMapManager {
         private messageBus: IMessageBus,
         private gameDataProvider: IGameDataProvider,
         private tileSetManager: ITileSetManager,
-        private playerPositionManager: IPlayerPositionManager
+        private playerPositionManager: IPlayerPositionManager,
+        private logger: ILogger
     ){}
 
     /**
@@ -94,7 +97,9 @@ export class MapManager implements IMapManager {
      */
     public async setActiveMap(mapId: string): Promise<void> {
         const path = this.gameDataProvider.Game.game.maps[mapId]
-        if (!path) fatalError(logName, 'Map not found for id {0}', mapId)
+        if (!path) {
+            throw new Error(this.logger.error(logName, 'Map not found for id {0}', mapId))
+        }
 
         if (this.gameDataProvider.Game.loadedMaps[mapId] === undefined){
             const map = await this.gameMapLoader.loadMap(path)

--- a/tests/engine/mapManager.test.ts
+++ b/tests/engine/mapManager.test.ts
@@ -6,6 +6,7 @@ import type { IGameDataProvider, GameData, GameContext } from '../../engine/prov
 import type { ITileSetManager } from '../../engine/managers/tileSetManager'
 import type { IPlayerPositionManager } from '../../engine/managers/playerPositionManager'
 import { MAP_SWITCHED } from '../../engine/messages/system'
+import type { ILogger } from '../../utils/logger'
 
 function createProvider(gameData: GameData, context: GameContext): IGameDataProvider {
   return {
@@ -33,7 +34,15 @@ describe('MapManager.setActiveMap', () => {
     const postMessage = vi.fn()
     const messageBus = { registerMessageListener: vi.fn(), postMessage } as unknown as IMessageBus
 
-    const manager = new MapManager(mapLoader, messageBus, provider, tileSetManager, playerPositionManager)
+    const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const manager = new MapManager(
+      mapLoader,
+      messageBus,
+      provider,
+      tileSetManager,
+      playerPositionManager,
+      logger,
+    )
     await manager.setActiveMap('m1')
 
     expect(mapLoader.loadMap).toHaveBeenCalledWith('m1.json')
@@ -56,12 +65,14 @@ describe('MapManager.initialize', () => {
       registerMessageListener: register
     } as unknown as IMessageBus
 
+    const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
     const manager = new MapManager(
       {} as IGameMapLoader,
       messageBus,
       {} as IGameDataProvider,
       {} as ITileSetManager,
-      {} as IPlayerPositionManager
+      {} as IPlayerPositionManager,
+      logger,
     )
 
     manager.initialize()


### PR DESCRIPTION
## Summary
- inject ILogger via loggerToken into MapManager and use it for error reporting
- update MapManager tests to provide mock logger

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68a04dfc8a90833281866cba090805c7