### PR TITLE
Inject logger into PageManager

### DIFF
--- a/engine/managers/pageManager.ts
+++ b/engine/managers/pageManager.ts
@@ -4,9 +4,10 @@
  */
 import { Token, token } from '@ioc/token'
 import { gameDataProviderToken, IGameDataProvider } from '@providers/gameDataProvider'
-import { fatalError } from '@utils/logMessage'
 import { IPageLoader, pageLoaderToken } from '@loader/pageLoader'
 import { IMessageBus, messageBusToken } from '@utils/messageBus'
+import type { ILogger } from '@utils/logger'
+import { loggerToken } from '@utils/logger'
 import { CleanUp } from '@utils/types'
 import { PAGE_SWITCHED, SWITCH_PAGE } from '@messages/system'
 
@@ -31,7 +32,7 @@ export interface IPageManager {
 
 const logName = 'PageManager'
 export const pageManagerToken = token<IPageManager>(logName)
-export const pageManagerDependencies: Token<unknown>[] = [gameDataProviderToken, pageLoaderToken, messageBusToken]
+export const pageManagerDependencies: Token<unknown>[] = [gameDataProviderToken, pageLoaderToken, messageBusToken, loggerToken]
 /**
  * Default implementation of {@link IPageManager} that integrates with the
  * game's data provider and message bus to control page transitions.
@@ -50,7 +51,8 @@ export class PageManager implements IPageManager {
     constructor(
         private gameDataProvider: IGameDataProvider,
         private pageLoader: IPageLoader,
-        private messageBus: IMessageBus
+        private messageBus: IMessageBus,
+        private logger: ILogger
     ) {
     }
 
@@ -83,7 +85,9 @@ export class PageManager implements IPageManager {
      */
     public async setActivePage(pageId: string): Promise<void> {
         const path = this.gameDataProvider.Game.game.pages[pageId]
-        if (!path) fatalError(logName, 'Page not found for id {0}', pageId)
+        if (!path) {
+            throw new Error(this.logger.error(logName, 'Page not found for id {0}', pageId))
+        }
 
         if (this.gameDataProvider.Game.loadedPages[pageId] === undefined) {
             const page = await this.pageLoader.loadPage(path)

--- a/tests/engine/pageManager.test.ts
+++ b/tests/engine/pageManager.test.ts
@@ -4,6 +4,7 @@ import { SWITCH_PAGE, PAGE_SWITCHED } from '../../engine/messages/system'
 import type { IMessageBus } from '../../utils/messageBus'
 import type { IGameDataProvider, GameData, GameContext } from '../../engine/providers/gameDataProvider'
 import type { IPageLoader } from '../../engine/loader/pageLoader'
+import type { ILogger } from '../../utils/logger'
 
 type Msg = { message: string, payload: unknown }
 
@@ -40,7 +41,8 @@ describe('PageManager', () => {
     } as unknown as IGameDataProvider
     const loadPage = vi.fn().mockResolvedValue({ id: 'home' })
     const loader = { loadPage } as unknown as IPageLoader
-    const manager = new PageManager(provider, loader, bus)
+    const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const manager = new PageManager(provider, loader, bus, logger)
 
     await manager.setActivePage('home')
 
@@ -54,7 +56,8 @@ describe('PageManager', () => {
     const bus = createBus()
     const provider = {} as IGameDataProvider
     const loader = {} as IPageLoader
-    const manager = new PageManager(provider, loader, bus)
+    const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const manager = new PageManager(provider, loader, bus, logger)
     manager.initialize()
     const spy = vi.spyOn(manager, 'setActivePage').mockResolvedValue(undefined)
 


### PR DESCRIPTION
## Summary
- inject ILogger into PageManager via DI
- log errors with logger.error and throw when page missing
- adjust PageManager tests for logger dependency

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68a04dff9e248332ad09a20090c1cb6b