### PR TITLE
refactor: inject logger into tile set manager

### DIFF
--- a/engine/managers/tileSetManager.ts
+++ b/engine/managers/tileSetManager.ts
@@ -1,7 +1,8 @@
 import { Token, token } from '@ioc/token'
 import { ITileSetLoader, tileSetLoaderToken } from '@loader/tileSetLoader'
-import { fatalError } from '@utils/logMessage'
 import { gameDataProviderToken, IGameDataProvider } from '@providers/gameDataProvider'
+import type { ILogger } from '@utils/logger'
+import { loggerToken } from '@utils/logger'
 
 /**
  * Handles loading of tile sets required by maps.
@@ -14,7 +15,8 @@ const logName = 'TileSetManager'
 export const tileSetManagerToken = token<ITileSetManager>(logName)
 export const tileSetManagerDependencies: Token<unknown>[] = [
     gameDataProviderToken,
-    tileSetLoaderToken
+    tileSetLoaderToken,
+    loggerToken
 ]
 
 /**
@@ -23,7 +25,8 @@ export const tileSetManagerDependencies: Token<unknown>[] = [
 export class TileSetManager implements ITileSetManager {
     constructor(
         private gameDataProvider: IGameDataProvider,
-        private tileSetLoader: ITileSetLoader
+        private tileSetLoader: ITileSetLoader,
+        private logger: ILogger
     ) {}
 
     /**
@@ -37,7 +40,10 @@ export class TileSetManager implements ITileSetManager {
         await Promise.all(
             tileSetIds.map(async tileSetId => {
                 const path = this.gameDataProvider.Game.game.tiles[tileSetId]
-                if (!path) fatalError(logName, 'Tile set not found for id {0}', tileSetId)
+                if (!path) {
+                    this.logger.error(logName, 'Tile set not found for id {0}', tileSetId)
+                    throw new Error(`Tile set not found for id ${tileSetId}`)
+                }
 
                 if (!this.gameDataProvider.Game.loadedTileSets.has(tileSetId)) {
                     const tileSet = await this.tileSetLoader.loadTileSet(path)

--- a/tests/engine/tileSetManager.test.ts
+++ b/tests/engine/tileSetManager.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import { TileSetManager } from '../../engine/managers/tileSetManager'
 import type { IGameDataProvider, GameData, GameContext } from '../../engine/providers/gameDataProvider'
 import type { ITileSetLoader } from '../../engine/loader/tileSetLoader'
+import type { ILogger } from '../../utils/logger'
 
 function createManager(gameData: GameData, loadTileSet: ReturnType<typeof vi.fn>) {
   const provider = {
@@ -10,7 +11,13 @@ function createManager(gameData: GameData, loadTileSet: ReturnType<typeof vi.fn>
     initialize: vi.fn(),
   } as unknown as IGameDataProvider
   const tileSetLoader = { loadTileSet } as unknown as ITileSetLoader
-  return new TileSetManager(provider, tileSetLoader)
+  const logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  } as unknown as ILogger
+  return new TileSetManager(provider, tileSetLoader, logger)
 }
 
 describe('TileSetManager.ensureTileSets', () => {


### PR DESCRIPTION
## Summary
- inject ILogger into TileSetManager and convert fatalError to error/throw
- update TileSetManager tests for logger dependency

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68a04e00f1c083328d6116bbb1cd3e0d