### PR TITLE
refactor: use z.number().int() in schemas

### DIFF
--- a/engine/loader/schema/component.ts
+++ b/engine/loader/schema/component.ts
@@ -14,16 +14,16 @@ const imageComponentSchema = z.object({
 const squaresMapComponentSchema = z.object({
     type: z.literal('squares-map'),
     mapSize: z.object({
-        rows: z.int().positive(),
-        columns: z.int().positive()
+        rows: z.number().int().positive(),
+        columns: z.number().int().positive()
     })
 })
 
 const inputMatrxComponentSchema = z.object({
     type: z.literal('input-matrix'),
     matrixSize: z.object({
-        width: z.int().positive(),
-        height: z.int().positive()
+        width: z.number().int().positive(),
+        height: z.number().int().positive()
     })
 })
 
@@ -41,7 +41,7 @@ const characterComponentSchema = z.object({
 
 const outputComponentSchema = z.object({
     type: z.literal('output-log'),
-    logSize: z.int().positive()
+    logSize: z.number().int().positive()
 })
 
 export const componentSchema = z.discriminatedUnion('type', [

--- a/engine/loader/schema/inputs.ts
+++ b/engine/loader/schema/inputs.ts
@@ -4,8 +4,8 @@ import { actionSchema } from './action'
 
 export const inputSchema = z.object({
     virtualInput: z.string(),
-    preferredRow: z.int().nonnegative().optional(),
-    preferredCol: z.int().nonnegative().optional(),
+    preferredRow: z.number().int().nonnegative().optional(),
+    preferredCol: z.number().int().nonnegative().optional(),
     label: z.string(),
     description: z.string(),
     visible: conditionSchema,

--- a/engine/loader/schema/map.ts
+++ b/engine/loader/schema/map.ts
@@ -10,16 +10,16 @@ export const mapTileSchema = z.object({
 export const squaresMapSchema = z.object({
     key: z.string(),
     type: z.literal('squares-map'),
-    width: z.int().positive(),
-    height: z.int().positive(),
+    width: z.number().int().positive(),
+    height: z.number().int().positive(),
     tileSets: z.array(z.string()),
     tiles: z.array(mapTileSchema),
     map: z.array(z.string()),
 })
 
 export const positionSchema = z.object({
-    x: z.int().nonnegative(),
-    y: z.int().nonnegative()
+    x: z.number().int().nonnegative(),
+    y: z.number().int().nonnegative()
 })
 
 export const gameMapSchema = z.discriminatedUnion('type', [squaresMapSchema])

--- a/engine/loader/schema/page.ts
+++ b/engine/loader/schema/page.ts
@@ -4,10 +4,10 @@ import { inputSchema } from './inputs'
 import { conditionSchema } from './condition'
 
 const gridScreenPositionSchema = z.object({
-    top: z.int().nonnegative(),
-    left: z.int().nonnegative(),
-    right: z.int().nonnegative(),
-    bottom: z.int().nonnegative()
+    top: z.number().int().nonnegative(),
+    left: z.number().int().nonnegative(),
+    right: z.number().int().nonnegative(),
+    bottom: z.number().int().nonnegative()
 })
 
 const gridScreenItemSchema = z.object({
@@ -18,8 +18,8 @@ const gridScreenItemSchema = z.object({
 
 const gridScreenSchema = z.object({
     type: z.literal('grid'),
-    width: z.int().positive(),
-    height: z.int().positive(),
+    width: z.number().int().positive(),
+    height: z.number().int().positive(),
     components: z.array(gridScreenItemSchema),
 })
 const screenSchema = z.discriminatedUnion('type', [gridScreenSchema])


### PR DESCRIPTION
## Summary
- refactor schema files to use `z.number().int()` instead of deprecated `z.int`
- preserve existing numeric constraints like `.positive()` and `.nonnegative()`

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68a05267228483328dd26cbe1e5dfd63