### PR TITLE
refactor: standardize provider variable naming

### DIFF
--- a/engine/providers/virtualInputProvider.ts
+++ b/engine/providers/virtualInputProvider.ts
@@ -28,11 +28,11 @@ export const virtualInputProviderDependencies: Token<unknown>[] = [
     gameDataProviderToken
 ]
 export class VirtualInputProvider implements IVirtualInputProvider {
-    private CleanUpFn: CleanUp | null = null
+    private cleanupFn: CleanUp | null = null
 
     constructor(
         private virtualInputsLoader: IVirtualInputsLoader,
-        private messagebus: IMessageBus,
+        private messageBus: IMessageBus,
         private gameDataProvider: IGameDataProvider
     ) {}
 
@@ -51,11 +51,11 @@ export class VirtualInputProvider implements IVirtualInputProvider {
      */
     public async initialize(): Promise<void> {
         if (this.gameDataProvider.Game.loadedVirtualInputs.size === 0) await this.loadVirtualInputs()
-        this.CleanUpFn = this.messagebus.registerMessageListener(
+        this.cleanupFn = this.messageBus.registerMessageListener(
             VIRTUAL_KEY,
             message => {
                 if (message.payload && this.gameDataProvider.Game.loadedVirtualInputs.has(message.payload as string)) {
-                    this.messagebus.postMessage({
+                    this.messageBus.postMessage({
                         message: VIRTUAL_INPUT,
                         payload: this.gameDataProvider.Game.loadedVirtualInputs.get(message.payload as string)?.virtualInput
                     })
@@ -74,8 +74,8 @@ export class VirtualInputProvider implements IVirtualInputProvider {
      *   duplicate registrations.
      */
     public cleanup(): void {
-        this.CleanUpFn?.()
-        this.CleanUpFn = null
+        this.cleanupFn?.()
+        this.cleanupFn = null
     }
 
     /**
@@ -84,7 +84,7 @@ export class VirtualInputProvider implements IVirtualInputProvider {
      * game data provider's state.
      */
     private async loadVirtualInputs(): Promise<void> {
-        var inputs = await this.virtualInputsLoader.loadVirtualInputs(this.gameDataProvider.Game.game.virtualInputs)
+        const inputs = await this.virtualInputsLoader.loadVirtualInputs(this.gameDataProvider.Game.game.virtualInputs)
         inputs.forEach(input => {
             input.virtualKeys.forEach(virtualKey => this.gameDataProvider.Game.loadedVirtualInputs.set(virtualKey, input))
         })

--- a/engine/providers/virtualKeyProvider.ts
+++ b/engine/providers/virtualKeyProvider.ts
@@ -33,7 +33,7 @@ export const virtualKeyProviderDependencies: Token<unknown>[] = [
     gameDataProviderToken
 ]
 export class VirtualKeyProvider implements IVirtualKeyProvider {
-    private CleanUpFn: CleanUp | null = null
+    private cleanupFn: CleanUp | null = null
 
     constructor(
         private keyboardEventListener: IKeyboardEventListener,
@@ -56,8 +56,8 @@ export class VirtualKeyProvider implements IVirtualKeyProvider {
      */
     public async initialize(): Promise<void> {
         if (this.gameDataProvider.Game.loadedVirtualKeys.size === 0) await this.loadVirtualKeys()
-        this.CleanUpFn?.()
-        this.CleanUpFn = this.keyboardEventListener.addListener(event => {
+        this.cleanupFn?.()
+        this.cleanupFn = this.keyboardEventListener.addListener(event => {
             const lookupKey = this.createKey(event.code, event.alt, event.ctrl, event.shift)
             if (this.gameDataProvider.Game.loadedVirtualKeys.has(lookupKey)){
                 const virtualkey = this.gameDataProvider.Game.loadedVirtualKeys.get(lookupKey)
@@ -77,8 +77,8 @@ export class VirtualKeyProvider implements IVirtualKeyProvider {
      * - Clears the internal reference to the cleanup function.
      */
     public cleanup(): void {
-        this.CleanUpFn?.()
-        this.CleanUpFn = null
+        this.cleanupFn?.()
+        this.cleanupFn = null
     }
 
     /**
@@ -90,7 +90,7 @@ export class VirtualKeyProvider implements IVirtualKeyProvider {
      * @returns {Promise<void>} Resolves once all virtual key data has been loaded.
      */
     private async loadVirtualKeys(): Promise<void> {
-        var keys = await this.virtualKeysLoader.loadVirtualKeys(this.gameDataProvider.Game.game.virtualKeys)
+        const keys = await this.virtualKeysLoader.loadVirtualKeys(this.gameDataProvider.Game.game.virtualKeys)
         keys.forEach(key => {
             const lookupKey = this.createKey(key.keyCode, key.alt, key.ctrl, key.shift)
             this.gameDataProvider.Game.loadedVirtualKeys.set(lookupKey, key)


### PR DESCRIPTION
## Summary
- use camelCase for cleanupFn and messageBus in virtual providers
- replace var with const for loaded keys and inputs

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68a0527114ec8332abb413a93befe5f9