### PR TITLE
Rename keyboard event listener tokens for clarity

### DIFF
--- a/engine/builders/coreBuilder.ts
+++ b/engine/builders/coreBuilder.ts
@@ -5,7 +5,7 @@ import { Container } from '@ioc/container'
 import type { Container as IContainer } from '@ioc/types'
 import { MessageBus, messageBusDependencies, messageBusToken } from '@utils/messageBus'
 import { MessageQueue, messageQueueToken } from '@utils/messageQueue'
-import { KeyboardEventListener, keyboardeventListenerDependencies, keyboardeventListenerToken } from '@utils/keyboardEventListener'
+import { KeyboardEventListener, keyboardEventListenerDependencies, keyboardEventListenerToken } from '@utils/keyboardEventListener'
 import { loggerToken } from '@utils/logger'
 
 /**
@@ -43,9 +43,9 @@ export class CoreBuilder {
       deps: gameEngineDependencies
     })
     container.register({
-      token: keyboardeventListenerToken,
+      token: keyboardEventListenerToken,
       useClass: KeyboardEventListener,
-      deps: keyboardeventListenerDependencies
+      deps: keyboardEventListenerDependencies
     })
   }
 }

--- a/engine/providers/virtualKeyProvider.ts
+++ b/engine/providers/virtualKeyProvider.ts
@@ -1,6 +1,6 @@
 import { Token, token } from '@ioc/token'
 import { IVirtualKeysLoader, virtualKeysLoaderToken } from '@loader/virtualKeysLoader'
-import { IKeyboardEventListener, keyboardeventListenerToken } from '@utils/keyboardEventListener'
+import { IKeyboardEventListener, keyboardEventListenerToken } from '@utils/keyboardEventListener'
 import { IMessageBus, messageBusToken } from '@utils/messageBus'
 import { CleanUp } from '@utils/types'
 import { gameDataProviderToken, IGameDataProvider } from './gameDataProvider'
@@ -27,7 +27,7 @@ export interface IVirtualKeyProvider {
 const logName = 'VirtualKeyProvider'
 export const virtualKeyProviderToken = token<IVirtualKeyProvider>(logName)
 export const virtualKeyProviderDependencies: Token<unknown>[] = [
-    keyboardeventListenerToken,
+    keyboardEventListenerToken,
     messageBusToken,
     virtualKeysLoaderToken,
     gameDataProviderToken

--- a/tests/engine/coreBuilder.test.ts
+++ b/tests/engine/coreBuilder.test.ts
@@ -3,7 +3,7 @@ import { CoreBuilder } from '@builders/coreBuilder'
 import { engineInitializerToken } from '@engine/engineInitializer'
 import { gameEngineToken } from '@engine/gameEngine'
 import { turnSchedulerToken } from '@engine/turnScheduler'
-import { keyboardeventListenerToken } from '@utils/keyboardEventListener'
+import { keyboardEventListenerToken } from '@utils/keyboardEventListener'
 import { messageBusToken } from '@utils/messageBus'
 import { messageQueueToken } from '@utils/messageQueue'
 import { Container } from '@ioc/container'
@@ -33,7 +33,7 @@ describe('coreBuilder', () => {
         messageQueueToken,
         turnSchedulerToken,
         engineInitializerToken,
-        keyboardeventListenerToken,
+        keyboardEventListenerToken,
       ])
     )
   })

--- a/utils/keyboardEventListener.ts
+++ b/utils/keyboardEventListener.ts
@@ -41,8 +41,8 @@ export interface IKeyboardEventListener {
 }
 
 const logName = 'KeyboardEventListener'
-export const keyboardeventListenerToken = token<IKeyboardEventListener>(logName)
-export const keyboardeventListenerDependencies: Token<unknown>[] = []
+export const keyboardEventListenerToken = token<IKeyboardEventListener>(logName)
+export const keyboardEventListenerDependencies: Token<unknown>[] = []
 export class KeyboardEventListener implements IKeyboardEventListener {
     private key: number = 0
     private listeners: EventListener[] = []


### PR DESCRIPTION
## Summary
- Rename keyboardeventListenerToken and keyboardeventListenerDependencies to keyboardEventListenerToken and keyboardEventListenerDependencies
- Update imports and dependency registrations to use new token names
- Adjust tests to reference updated token name

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68a0526c28988332aa4c93bf538cb82f