### PR TITLE
Rename ActionExecuter to ActionExecutor

### DIFF
--- a/engine/actions/actionExecutor.ts
+++ b/engine/actions/actionExecutor.ts
@@ -8,7 +8,7 @@ import { Message } from '@utils/types'
 /**
  * Executes actions using registered action handlers.
  */
-export interface IActionExecuter {
+export interface IActionExecutor {
     /**
      * Executes the provided action by resolving and invoking its handler.
      *
@@ -20,17 +20,17 @@ export interface IActionExecuter {
     execute<T extends BaseAction = Action>(action: T, message?: Message, data?: unknown): void
 }
 
-const logName = 'ActionExecuter'
-export const actionExecuterToken = token<IActionExecuter>(logName)
-export const actionExecuterDependencies: Token<unknown>[] = [actionHandlerRegistryToken, loggerToken]
+const logName = 'ActionExecutor'
+export const actionExecutorToken = token<IActionExecutor>(logName)
+export const actionExecutorDependencies: Token<unknown>[] = [actionHandlerRegistryToken, loggerToken]
 
 /**
- * Default implementation of {@link IActionExecuter} that delegates work to
+ * Default implementation of {@link IActionExecutor} that delegates work to
  * action handlers resolved from a registry.
  */
-export class ActionExecuter implements IActionExecuter {
+export class ActionExecutor implements IActionExecutor {
     /**
-     * Creates a new {@link ActionExecuter}.
+     * Creates a new {@link ActionExecutor}.
      *
      * @param actionHandlerRegistry - Registry used to look up action handlers.
      * @param logger - Logger used to report errors.

--- a/engine/app/controls/component/gameMenuComponent.tsx
+++ b/engine/app/controls/component/gameMenuComponent.tsx
@@ -2,7 +2,7 @@ import { GameMenuComponent as GameMenuComponentData } from '@loader/data/compone
 import { Button } from '@loader/data/button'
 import { ITranslationService, translationServiceToken } from '@services/translationService'
 import { useService } from '@app/iocProvider'
-import { actionExecuterToken, IActionExecuter } from '@actions/actionExecuter'
+import { actionExecutorToken, IActionExecutor } from '@actions/actionExecutor'
 
 interface GameMenuComponentProps {
     component: GameMenuComponentData
@@ -15,10 +15,10 @@ interface GameMenuComponentProps {
  */
 export const GameMenuComponent: React.FC<GameMenuComponentProps> = ({ component }): React.JSX.Element => {
     const translationService = useService<ITranslationService>(translationServiceToken)
-    const actionExecuter = useService<IActionExecuter>(actionExecuterToken)
+    const actionExecutor = useService<IActionExecutor>(actionExecutorToken)
 
     const onButtonClick = (button: Button) => {
-        actionExecuter.execute(button.action)
+        actionExecutor.execute(button.action)
     }
 
     return (

--- a/engine/builders/actionsBuilder.ts
+++ b/engine/builders/actionsBuilder.ts
@@ -1,5 +1,5 @@
 import { Container } from '@ioc/container'
-import { ActionExecuter, actionExecuterDependencies, actionExecuterToken } from '@actions/actionExecuter'
+import { ActionExecutor, actionExecutorDependencies, actionExecutorToken } from '@actions/actionExecutor'
 import { PostMessageAction, PostMessageActionDependencies, postMessageActionToken } from '@actions/postMessageAction'
 
 /**
@@ -11,9 +11,9 @@ export class ActionsBuilder {
    */
   register(container: Container): void {
     container.register({
-      token: actionExecuterToken,
-      useClass: ActionExecuter,
-      deps: actionExecuterDependencies
+      token: actionExecutorToken,
+      useClass: ActionExecutor,
+      deps: actionExecutorDependencies
     })
     container.register({
       token: postMessageActionToken,

--- a/engine/managers/actionManager.ts
+++ b/engine/managers/actionManager.ts
@@ -1,4 +1,4 @@
-import { actionExecuterToken, IActionExecuter } from '@actions/actionExecuter'
+import { actionExecutorToken, IActionExecutor } from '@actions/actionExecutor'
 import { Token, token } from '@ioc/token'
 import { actionHandlersLoaderToken, IActionHandlersLoader } from '@loader/actionHandlersLoader'
 import { gameDataProviderToken, IGameDataProvider } from '@providers/gameDataProvider'
@@ -28,7 +28,7 @@ export const actionManagerDependencies: Token<unknown>[] = [
     actionHandlersLoaderToken, 
     messageBusToken, 
     gameDataProviderToken,
-    actionExecuterToken
+    actionExecutorToken
 ]
 /**
  * Default implementation of {@link IActionManager} that loads action
@@ -53,7 +53,7 @@ export class ActionManager implements IActionManager {
         private actionHandlersLoader: IActionHandlersLoader,
         private messageBus: IMessageBus,
         private gameDataProvider: IGameDataProvider,
-        private actionExecutor: IActionExecuter
+        private actionExecutor: IActionExecutor
     ) {}
 
     /**

--- a/tests/app/GameMenuComponent.test.tsx
+++ b/tests/app/GameMenuComponent.test.tsx
@@ -4,7 +4,7 @@ import { render, screen, fireEvent } from '@testing-library/react'
 import { services } from './testUtils'
 import { GameMenuComponent } from '@app/controls/component/gameMenuComponent'
 import { translationServiceToken, type ITranslationService } from '@services/translationService'
-import { actionExecuterToken, type IActionExecuter } from '@actions/actionExecuter'
+import { actionExecutorToken, type IActionExecutor } from '@actions/actionExecutor'
 import { GameMenuComponent as GameMenuComponentData } from '@loader/data/component'
 
 describe('GameMenuComponent', () => {
@@ -12,9 +12,9 @@ describe('GameMenuComponent', () => {
 
   it('renders translated buttons and executes action on click', () => {
     const translationService = { translate: vi.fn((label: string) => `tr-${label}`) } as unknown as ITranslationService
-    const actionExecuter = { execute: vi.fn() } as unknown as IActionExecuter
+    const actionExecutor = { execute: vi.fn() } as unknown as IActionExecutor
     services.set(translationServiceToken, translationService)
-    services.set(actionExecuterToken, actionExecuter)
+    services.set(actionExecutorToken, actionExecutor)
 
     const component: GameMenuComponentData = {
       type: 'game-menu',
@@ -29,14 +29,14 @@ describe('GameMenuComponent', () => {
     fireEvent.click(button)
 
     expect(translationService.translate).toHaveBeenCalledWith('start')
-    expect(actionExecuter.execute).toHaveBeenCalledWith(component.buttons[0].action)
+    expect(actionExecutor.execute).toHaveBeenCalledWith(component.buttons[0].action)
   })
 
   it('renders empty menu when no buttons provided', () => {
     const translationService = { translate: vi.fn() } as unknown as ITranslationService
-    const actionExecuter = { execute: vi.fn() } as unknown as IActionExecuter
+    const actionExecutor = { execute: vi.fn() } as unknown as IActionExecutor
     services.set(translationServiceToken, translationService)
-    services.set(actionExecuterToken, actionExecuter)
+    services.set(actionExecutorToken, actionExecutor)
 
     const component: GameMenuComponentData = { type: 'game-menu', buttons: [] }
 

--- a/tests/engine/actionExecutor.test.ts
+++ b/tests/engine/actionExecutor.test.ts
@@ -1,15 +1,15 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { ActionExecuter } from '@actions/actionExecuter'
+import { ActionExecutor } from '@actions/actionExecutor'
 import type { BaseAction } from '@loader/data/action'
 import type { ActionHandlerRegistry } from '@registries/actionHandlerRegistry'
 import type { ILogger } from '@utils/logger'
 
 const KNOWN_TYPE = 'known-action'
 
-describe('ActionExecuter', () => {
+describe('ActionExecutor', () => {
     let handler: { handle: ReturnType<typeof vi.fn> }
     let registry: ActionHandlerRegistry
-    let executer: ActionExecuter
+    let executor: ActionExecutor
     let logger: ILogger
 
     beforeEach(() => {
@@ -18,19 +18,19 @@ describe('ActionExecuter', () => {
             getActionHandler: vi.fn((type: string) => (type === KNOWN_TYPE ? handler : undefined))
         } as unknown as ActionHandlerRegistry
         logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
-        executer = new ActionExecuter(registry, logger)
+        executor = new ActionExecutor(registry, logger)
     })
 
     it('invokes handler when registered', () => {
         const action = { type: KNOWN_TYPE } as BaseAction
-        executer.execute(action)
+        executor.execute(action)
         expect(handler.handle).toHaveBeenCalledWith(action, undefined, undefined)
     })
 
     it('logs and throws when handler missing', () => {
         const action = { type: 'missing-action' } as BaseAction
-        expect(() => executer.execute(action)).toThrow('No action handler found for type missing-action')
-        expect(logger.error).toHaveBeenCalledWith('ActionExecuter', 'No action handler found for type {0}', 'missing-action')
+        expect(() => executor.execute(action)).toThrow('No action handler found for type missing-action')
+        expect(logger.error).toHaveBeenCalledWith('ActionExecutor', 'No action handler found for type {0}', 'missing-action')
     })
 })
 

--- a/tests/engine/actionManager.test.ts
+++ b/tests/engine/actionManager.test.ts
@@ -3,7 +3,7 @@ import { ActionManager } from '@managers/actionManager'
 import type { IActionHandlersLoader } from '@loader/actionHandlersLoader'
 import type { IMessageBus } from '@utils/messageBus'
 import type { IGameDataProvider, GameData, GameContext } from '@providers/gameDataProvider'
-import type { IActionExecuter } from '@actions/actionExecuter'
+import type { IActionExecutor } from '@actions/actionExecutor'
 import type { Message } from '@utils/types'
 
 
@@ -48,9 +48,9 @@ describe('ActionManager', () => {
     }
 
     const execute = vi.fn()
-    const actionExecuter: IActionExecuter = { execute }
+    const actionExecutor: IActionExecutor = { execute }
 
-    const manager = new ActionManager(actionHandlersLoader, messageBus, gameDataProvider, actionExecuter)
+    const manager = new ActionManager(actionHandlersLoader, messageBus, gameDataProvider, actionExecutor)
     await manager.initialize()
 
     expect(loadActions).toHaveBeenCalledWith(['path1'])
@@ -108,9 +108,9 @@ describe('ActionManager', () => {
       initialize: vi.fn()
     }
 
-    const actionExecuter: IActionExecuter = { execute: vi.fn() }
+    const actionExecutor: IActionExecutor = { execute: vi.fn() }
 
-    const manager = new ActionManager(actionHandlersLoader, messageBus, gameDataProvider, actionExecuter)
+    const manager = new ActionManager(actionHandlersLoader, messageBus, gameDataProvider, actionExecutor)
 
     await manager.initialize()
     const firstCleanupSpies = [...cleanupSpies]

--- a/tests/engine/engineInitializer.test.ts
+++ b/tests/engine/engineInitializer.test.ts
@@ -14,6 +14,7 @@ import type { IActionManager } from '../../engine/managers/actionManager'
 import type { IMapManager } from '../../engine/managers/mapManager'
 import type { IVirtualKeyProvider } from '../../engine/providers/virtualKeyProvider'
 import type { IVirtualInputProvider } from '../../engine/providers/virtualInputProvider'
+import type { ITurnManager } from '../../engine/managers/turnManager'
 import type { Game } from '../../engine/loader/data/game'
 
 describe('EngineInitializer', () => {
@@ -45,6 +46,7 @@ describe('EngineInitializer', () => {
     const mapManager = { initialize: vi.fn() } as unknown as IMapManager
     const virtualKeyProvider = { initialize: vi.fn() } as unknown as IVirtualKeyProvider
     const virtualInputProvider = { initialize: vi.fn() } as unknown as IVirtualInputProvider
+    const turnManager = { initialize: vi.fn() } as unknown as ITurnManager
 
     const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
     const initializer = new EngineInitializer(
@@ -59,7 +61,8 @@ describe('EngineInitializer', () => {
       mapManager,
       virtualKeyProvider,
       virtualInputProvider,
-      logger
+      logger,
+      turnManager
     )
 
     await initializer.initialize()

--- a/tests/engine/managerBuilder.test.ts
+++ b/tests/engine/managerBuilder.test.ts
@@ -7,6 +7,7 @@ import { mapManagerToken } from '@managers/mapManager'
 import { pageManagerToken } from '@managers/pageManager'
 import { tileSetManagerToken } from '@managers/tileSetManager'
 import { playerPositionManagerToken } from '@managers/playerPositionManager'
+import { turnmanagerToken } from '@managers/turnManager'
 import { Container } from '@ioc/container'
 import type { Token } from '@ioc/token'
 import type { ILogger } from '@utils/logger'
@@ -18,15 +19,14 @@ describe('managersBuilder', () => {
       debug: vi.fn(),
       info: vi.fn(),
       warn: vi.fn(),
-      error: vi.fn((category: string, message: string, ...args: unknown[]) =>
-        `[${category}] ${message.replace(/\{(\d+)\}/g, (_: string, i: string) => String(args[Number(i)]))}`),
+      error: vi.fn()
     }
     const container = new Container(logger)
     builder.register(container)
 
     const registeredTokens = Array.from(
       (container as unknown as { providers: Map<Token<unknown>, unknown> }).providers.keys()
-    )
+    ).map(String)
     expect(new Set(registeredTokens)).toEqual(
       new Set([
         domManagerToken,
@@ -36,7 +36,8 @@ describe('managersBuilder', () => {
         tileSetManagerToken,
         playerPositionManagerToken,
         mapManagerToken,
-      ])
+        turnmanagerToken,
+      ].map(String))
     )
   })
 })


### PR DESCRIPTION
## Summary
- Rename action executer to action executor and update interface, token, and dependency names
- Adjust builders, managers, components, and tests to use ActionExecutor
- Fix related tests and initialization stubs

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68a08ae604d0833293ee7f3bcc1b55b2