### PR TITLE
Rename turnmanager token to turnManagerToken

### DIFF
--- a/engine/builders/managersBuilder.ts
+++ b/engine/builders/managersBuilder.ts
@@ -6,7 +6,7 @@ import { MapManager, mapManagerDependencies, mapManagerToken } from '@managers/m
 import { PageManager, pageManagerDependencies, pageManagerToken } from '@managers/pageManager'
 import { TileSetManager, tileSetManagerDependencies, tileSetManagerToken } from '@managers/tileSetManager'
 import { PlayerPositionManager, playerPositionManagerDependencies, playerPositionManagerToken } from '@managers/playerPositionManager'
-import { TurnManager, turnManagerDependencies, turnmanagerToken } from '@managers/turnManager'
+import { TurnManager, turnManagerDependencies, turnManagerToken } from '@managers/turnManager'
 
 /**
  * Registers manager classes that orchestrate major engine systems.
@@ -53,7 +53,7 @@ export class ManagersBuilder {
       deps: mapManagerDependencies
     })
     container.register({
-      token: turnmanagerToken,
+      token: turnManagerToken,
       useClass: TurnManager,
       deps: turnManagerDependencies
     })

--- a/engine/engine/engineInitializer.ts
+++ b/engine/engine/engineInitializer.ts
@@ -16,7 +16,7 @@ import { actionManagerToken, IActionManager } from '@managers/actionManager'
 import { IMapManager, mapManagerToken } from '@managers/mapManager'
 import { IVirtualKeyProvider, virtualKeyProviderToken } from '@providers/virtualKeyProvider'
 import { IVirtualInputProvider, virtualInputProviderToken } from '@providers/virtualInputProvider'
-import { ITurnManager, turnmanagerToken } from '@managers/turnManager'
+import { ITurnManager, turnManagerToken } from '@managers/turnManager'
 
 /**
  * Contract for components that prepare and start the game engine.
@@ -45,7 +45,7 @@ export const engineInitializerDependencies: Token<unknown>[] = [
     virtualKeyProviderToken,
     virtualInputProviderToken,
     loggerToken,
-    turnmanagerToken
+    turnManagerToken
 ]
 /**
  * Default {@link IEngineInitializer} implementation that orchestrates loading

--- a/engine/managers/turnManager.ts
+++ b/engine/managers/turnManager.ts
@@ -10,7 +10,7 @@ export interface ITurnManager {
 }
 
 const logName = 'TurnManager'
-export const turnmanagerToken = token<ITurnManager>(logName)
+export const turnManagerToken = token<ITurnManager>(logName)
 export const turnManagerDependencies: Token<unknown>[] = [inputSourcesServiceToken, messageBusToken]
 export class TurnManager implements ITurnManager {
     private cleanupFns: CleanUp[] | null = null

--- a/tests/engine/engineInitializer.test.ts
+++ b/tests/engine/engineInitializer.test.ts
@@ -15,6 +15,7 @@ import type { IMapManager } from '../../engine/managers/mapManager'
 import type { IVirtualKeyProvider } from '../../engine/providers/virtualKeyProvider'
 import type { IVirtualInputProvider } from '../../engine/providers/virtualInputProvider'
 import type { Game } from '../../engine/loader/data/game'
+import type { ITurnManager } from '../../engine/managers/turnManager'
 
 describe('EngineInitializer', () => {
   it('initializes engine and posts start messages', async () => {
@@ -45,6 +46,7 @@ describe('EngineInitializer', () => {
     const mapManager = { initialize: vi.fn() } as unknown as IMapManager
     const virtualKeyProvider = { initialize: vi.fn() } as unknown as IVirtualKeyProvider
     const virtualInputProvider = { initialize: vi.fn() } as unknown as IVirtualInputProvider
+    const turnManager = { initialize: vi.fn() } as unknown as ITurnManager
 
     const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
     const initializer = new EngineInitializer(
@@ -59,7 +61,8 @@ describe('EngineInitializer', () => {
       mapManager,
       virtualKeyProvider,
       virtualInputProvider,
-      logger
+      logger,
+      turnManager
     )
 
     await initializer.initialize()
@@ -69,6 +72,7 @@ describe('EngineInitializer', () => {
     expect(pageManager.initialize).toHaveBeenCalledTimes(1)
     expect(actionManager.initialize).toHaveBeenCalledTimes(1)
     expect(mapManager.initialize).toHaveBeenCalledTimes(1)
+    expect(turnManager.initialize).toHaveBeenCalledTimes(1)
     expect(virtualKeyProvider.initialize).toHaveBeenCalledTimes(1)
     expect(virtualInputProvider.initialize).toHaveBeenCalledTimes(1)
     expect(languageManager.setLanguage).toHaveBeenCalledWith('en')

--- a/tests/engine/managerBuilder.test.ts
+++ b/tests/engine/managerBuilder.test.ts
@@ -7,6 +7,7 @@ import { mapManagerToken } from '@managers/mapManager'
 import { pageManagerToken } from '@managers/pageManager'
 import { tileSetManagerToken } from '@managers/tileSetManager'
 import { playerPositionManagerToken } from '@managers/playerPositionManager'
+import { turnManagerToken } from '@managers/turnManager'
 import { Container } from '@ioc/container'
 import type { Token } from '@ioc/token'
 import type { ILogger } from '@utils/logger'
@@ -36,6 +37,7 @@ describe('managersBuilder', () => {
         tileSetManagerToken,
         playerPositionManagerToken,
         mapManagerToken,
+        turnManagerToken,
       ])
     )
   })


### PR DESCRIPTION
## Summary
- Rename `turnmanagerToken` to `turnManagerToken` and update all usages
- Adjust managers builder and engine initializer imports and dependencies
- Update tests to include and mock the turn manager

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68a08af1f69c8332ade5c2af7a309412