### PR TITLE
refactor: use lower camelCase for postMessageAction dependencies

### DIFF
--- a/engine/actions/postMessageAction.ts
+++ b/engine/actions/postMessageAction.ts
@@ -11,7 +11,7 @@ export type IPostMessageAction = IActionHandler<PostMessageActionData>
 
 const logName = 'PostMessageAction'
 export const postMessageActionToken = token<IPostMessageAction>(logName)
-export const PostMessageActionDependencies: Token<unknown>[] = [messageBusToken]
+export const postMessageActionDependencies: Token<unknown>[] = [messageBusToken]
 
 /**
  * {@link IActionHandler} implementation that forwards actions to the

--- a/engine/builders/actionsBuilder.ts
+++ b/engine/builders/actionsBuilder.ts
@@ -1,6 +1,6 @@
 import { Container } from '@ioc/container'
 import { ActionExecutor, actionExecutorDependencies, actionExecutorToken } from '@actions/actionExecutor'
-import { PostMessageAction, PostMessageActionDependencies, postMessageActionToken } from '@actions/postMessageAction'
+import { PostMessageAction, postMessageActionDependencies, postMessageActionToken } from '@actions/postMessageAction'
 
 /**
  * Registers action related services and predefined actions.
@@ -18,7 +18,7 @@ export class ActionsBuilder {
     container.register({
       token: postMessageActionToken,
       useClass: PostMessageAction,
-      deps: PostMessageActionDependencies,
+      deps: postMessageActionDependencies,
       scope: 'transient'
     })
   }

--- a/tests/engine/engineInitializer.test.ts
+++ b/tests/engine/engineInitializer.test.ts
@@ -16,7 +16,6 @@ import type { IVirtualKeyProvider } from '../../engine/providers/virtualKeyProvi
 import type { IVirtualInputProvider } from '../../engine/providers/virtualInputProvider'
 import type { ITurnManager } from '../../engine/managers/turnManager'
 import type { Game } from '../../engine/loader/data/game'
-import type { ITurnManager } from '../../engine/managers/turnManager'
 
 describe('EngineInitializer', () => {
   it('initializes engine and posts start messages', async () => {

--- a/tests/engine/managerBuilder.test.ts
+++ b/tests/engine/managerBuilder.test.ts
@@ -7,7 +7,7 @@ import { mapManagerToken } from '@managers/mapManager'
 import { pageManagerToken } from '@managers/pageManager'
 import { tileSetManagerToken } from '@managers/tileSetManager'
 import { playerPositionManagerToken } from '@managers/playerPositionManager'
-import { turnmanagerToken } from '@managers/turnManager'
+import { turnManagerToken } from '@managers/turnManager'
 import { Container } from '@ioc/container'
 import type { Token } from '@ioc/token'
 import type { ILogger } from '@utils/logger'
@@ -36,7 +36,7 @@ describe('managersBuilder', () => {
         tileSetManagerToken,
         playerPositionManagerToken,
         mapManagerToken,
-        turnmanagerToken,
+        turnManagerToken,
       ].map(String))
     )
   })


### PR DESCRIPTION
## Summary
- rename `PostMessageActionDependencies` to `postMessageActionDependencies`
- update action builder and test imports
- fix broken tests for turn manager token

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68a18634bb088332b9a06c13422e17f9