### PR TITLE
refactor: log language loader validation errors

### DIFF
--- a/engine/loader/languageLoader.ts
+++ b/engine/loader/languageLoader.ts
@@ -10,7 +10,6 @@ import { loadJsonResource } from '@utils/loadJsonResource'
 import type { ILogger } from '@utils/logger'
 import { loggerToken } from '@utils/logger'
 import { mapLanguage } from './mappers/language'
-import { fatalError } from '@utils/logMessage'
 
 /**
  * Defines the contract for loading and merging language files.
@@ -48,7 +47,8 @@ export class LanguageLoader implements ILanguageLoader {
      */
     public async loadLanguage(paths: string[]): Promise<LanguageData> {
         if (paths.length === 0) {
-            fatalError(logName, 'No language paths provided')
+            this.logger.error(logName, 'No language paths provided')
+            throw new Error('No language paths provided')
         }
 
         const schemas = await Promise.all(
@@ -59,7 +59,15 @@ export class LanguageLoader implements ILanguageLoader {
         const sharedId = languages[0].id
         const mismatched = languages.find(lang => lang.id !== sharedId)
         if (mismatched) {
-            fatalError(logName, 'Language ID mismatch: expected {0} but got {1}', sharedId, mismatched.id)
+            this.logger.error(
+                logName,
+                'Language ID mismatch: expected {0} but got {1}',
+                sharedId,
+                mismatched.id
+            )
+            throw new Error(
+                `Language ID mismatch: expected ${sharedId} but got ${mismatched.id}`
+            )
         }
 
         return {

--- a/tests/engine/languageManager.test.ts
+++ b/tests/engine/languageManager.test.ts
@@ -73,6 +73,6 @@ describe('LanguageManager', () => {
     }
 
     const manager = new LanguageManager(loader, translationService, gameDataProvider, logger)
-    await expect(manager.setLanguage('empty')).rejects.toThrow('[LanguageLoader] No language paths provided')
+    await expect(manager.setLanguage('empty')).rejects.toThrow('No language paths provided')
   })
 })


### PR DESCRIPTION
## Summary
- replace fatalError with logger.error and throw Error in LanguageLoader
- adjust language manager test for new error message

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68a1b3f30d688332a57e20b98a7fa409