### PR TITLE
refactor: handle missing virtual input paths with logger and error

### DIFF
--- a/engine/loader/virtualInputsLoader.ts
+++ b/engine/loader/virtualInputsLoader.ts
@@ -1,7 +1,6 @@
 import { Token, token } from '@ioc/token'
 import { type VirtualInputs as VirtualInputsData } from './data/inputs'
 import { dataPathProviderToken, IDataPathProvider } from '@providers/configProviders'
-import { fatalError } from '@utils/logMessage'
 import { loadJsonResource } from '@utils/loadJsonResource'
 import type { ILogger } from '@utils/logger'
 import { loggerToken } from '@utils/logger'
@@ -50,7 +49,8 @@ export class VirtualInputsLoader implements IVirtualInputsLoader {
      */
     public async loadVirtualInputs(paths: string[]): Promise<VirtualInputsData> {
         if (paths.length === 0) {
-            fatalError(logName, 'No virtual inputs paths provided')
+            this.logger.error(logName, 'No virtual inputs paths provided')
+            throw new Error('No virtual inputs paths provided')
         }
 
         const schemas = await Promise.all(


### PR DESCRIPTION
## Summary
- log absence of virtual input paths instead of calling fatalError
- throw an error when no virtual input paths are provided

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68a1b3f738e483328ae064ba0e5de673