### PR TITLE
Log and throw when no action handler paths provided

### DIFF
--- a/engine/loader/actionHandlersLoader.ts
+++ b/engine/loader/actionHandlersLoader.ts
@@ -5,7 +5,6 @@ import { dataPathProviderToken, IDataPathProvider } from '@providers/configProvi
 import { loadJsonResource } from '@utils/loadJsonResource'
 import type { ILogger } from '@utils/logger'
 import { loggerToken } from '@utils/logger'
-import { fatalError } from '@utils/logMessage'
 import { mapHandlers } from './mappers/handler'
 
 /**
@@ -47,7 +46,8 @@ export class ActionHandlersLoader implements IActionHandlersLoader {
      */
     public async loadActions(paths: string[]): Promise<HandlersData> {
         if (paths.length === 0) {
-            fatalError(logName, 'No action handlers paths provided')
+            this.logger.error(logName, 'No action handlers paths provided')
+            throw new Error('No action handlers paths provided')
         }
 
         const schemas = await Promise.all(

--- a/tests/engine/actionHandlersLoader.test.ts
+++ b/tests/engine/actionHandlersLoader.test.ts
@@ -46,6 +46,7 @@ describe('ActionHandlersLoader', () => {
     const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
     const loader = new ActionHandlersLoader(dataPathProvider, logger)
     await expect(loader.loadActions([])).rejects.toThrow('No action handlers paths provided')
+    expect(logger.error).toHaveBeenCalledWith('ActionHandlersLoader', 'No action handlers paths provided')
   })
 
   it('throws when loadJsonResource rejects', async () => {


### PR DESCRIPTION
## Summary
- Log an error and throw when action handlers paths are missing instead of calling `fatalError`
- Test for missing handler paths now asserts logger error invocation

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68a1b3f959c88332aa6803c3ff2830e9