### PR TITLE
Update tests for new input manager and providers

### DIFF
--- a/tests/engine/containerBuilder.test.ts
+++ b/tests/engine/containerBuilder.test.ts
@@ -18,6 +18,8 @@ import { ProvidersBuilder } from '@builders/providersBuilder'
 import { MapManager, mapManagerToken } from '@managers/mapManager'
 import { TileSetManager, tileSetManagerToken } from '@managers/tileSetManager'
 import { PlayerPositionManager, playerPositionManagerToken } from '@managers/playerPositionManager'
+import { PageInputsProvider, pageInputsProviderToken } from '@inputs/pageInputsProvider'
+import { InputManager, inputManagerToken } from '@managers/inputManager'
 import type { ILogger } from '@utils/logger'
 
 describe('ContainerBuilder', () => {
@@ -31,6 +33,7 @@ describe('ContainerBuilder', () => {
     const mapManager = container.resolve(mapManagerToken)
     const tileSetManager = container.resolve(tileSetManagerToken)
     const playerPositionManager = container.resolve(playerPositionManagerToken)
+    const inputManager = container.resolve(inputManagerToken)
     expect(engine).toBeInstanceOf(GameEngine)
     expect(bus).toBeInstanceOf(MessageBus)
     expect(queue).toBeInstanceOf(MessageQueue)
@@ -38,13 +41,15 @@ describe('ContainerBuilder', () => {
     expect(mapManager).toBeInstanceOf(MapManager)
     expect(tileSetManager).toBeInstanceOf(TileSetManager)
     expect(playerPositionManager).toBeInstanceOf(PlayerPositionManager)
+    expect(inputManager).toBeInstanceOf(InputManager)
 
     const providers: { token: Token<unknown>, assert: (resolved: unknown) => void }[] = [
       { token: serviceProviderToken, assert: r => expect(r).toBeInstanceOf(ServiceProvider) },
       { token: dataPathProviderToken, assert: r => expect(r).toEqual({ dataPath: '/data' }) },
       { token: gameDataProviderToken, assert: r => expect(r).toBeInstanceOf(GameDataProvider) },
       { token: virtualKeyProviderToken, assert: r => expect(r).toBeInstanceOf(VirtualKeyProvider) },
-      { token: virtualInputProviderToken, assert: r => expect(r).toBeInstanceOf(VirtualInputProvider) }
+      { token: virtualInputProviderToken, assert: r => expect(r).toBeInstanceOf(VirtualInputProvider) },
+      { token: pageInputsProviderToken, assert: r => expect(r).toBeInstanceOf(PageInputsProvider) }
     ]
 
     providers.forEach(p => p.assert(container.resolve(p.token as Token<unknown>)))

--- a/tests/engine/engineInitializer.test.ts
+++ b/tests/engine/engineInitializer.test.ts
@@ -3,6 +3,7 @@ import { EngineInitializer } from '../../engine/core/engineInitializer'
 import type { ILogger } from '@utils/logger'
 import { START_GAME_ENGINE_MESSAGE, SWITCH_PAGE } from '../../engine/messages/system'
 import { postMessageActionToken } from '../../engine/actions/postMessageAction'
+import { scriptActionToken } from '../../engine/actions/scriptAction'
 import { scriptConditionToken } from '../../engine/conditions/scriptCondition'
 import type { IMessageBus } from '../../utils/messageBus'
 import type { IGameLoader } from '../../engine/loader/gameLoader'
@@ -19,6 +20,8 @@ import type { IVirtualInputProvider } from '../../engine/providers/virtualInputP
 import type { ITurnManager } from '../../engine/managers/turnManager'
 import type { IInputsProviderRegistry } from '../../engine/registries/inputsProviderRegistry'
 import type { Game } from '../../engine/loader/data/game'
+import type { IInputManager } from '../../engine/managers/inputManager'
+import { pageInputsProviderToken } from '../../engine/inputs/pageInputsProvider'
 
 describe('EngineInitializer', () => {
   it('initializes engine and posts start messages', async () => {
@@ -52,6 +55,7 @@ describe('EngineInitializer', () => {
     const virtualInputProvider = { initialize: vi.fn() } as unknown as IVirtualInputProvider
     const turnManager = { initialize: vi.fn() } as unknown as ITurnManager
     const inputsProviderRegistry = { registerInputsProvider: vi.fn() } as unknown as IInputsProviderRegistry
+    const inputManager = { initialize: vi.fn() } as unknown as IInputManager
 
     const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
     const initializer = new EngineInitializer(
@@ -69,7 +73,8 @@ describe('EngineInitializer', () => {
       virtualInputProvider,
       logger,
       turnManager,
-      inputsProviderRegistry
+      inputsProviderRegistry,
+      inputManager
     )
 
     await initializer.initialize()
@@ -80,6 +85,7 @@ describe('EngineInitializer', () => {
     expect(actionManager.initialize).toHaveBeenCalledTimes(1)
     expect(mapManager.initialize).toHaveBeenCalledTimes(1)
     expect(turnManager.initialize).toHaveBeenCalledTimes(1)
+    expect(inputManager.initialize).toHaveBeenCalledTimes(1)
     expect(virtualKeyProvider.initialize).toHaveBeenCalledTimes(1)
     expect(virtualInputProvider.initialize).toHaveBeenCalledTimes(1)
     expect(languageManager.setLanguage).toHaveBeenCalledWith('en')
@@ -87,9 +93,12 @@ describe('EngineInitializer', () => {
     expect(domManager.setCssFile).toHaveBeenCalledTimes(2)
     expect(domManager.setCssFile).toHaveBeenNthCalledWith(1, 'style1.css')
     expect(domManager.setCssFile).toHaveBeenNthCalledWith(2, 'style2.css')
-    expect(actionHandlerRegistry.registerActionHandler).toHaveBeenCalledTimes(1)
-    expect(actionHandlerRegistry.registerActionHandler).toHaveBeenCalledWith('post-message', postMessageActionToken)
+    expect(actionHandlerRegistry.registerActionHandler).toHaveBeenCalledTimes(2)
+    expect(actionHandlerRegistry.registerActionHandler).toHaveBeenNthCalledWith(1, 'post-message', postMessageActionToken)
+    expect(actionHandlerRegistry.registerActionHandler).toHaveBeenNthCalledWith(2, 'script', scriptActionToken)
     expect(conditionResolverRegistry.registerConditionResolver).toHaveBeenCalledWith('script', scriptConditionToken)
+    expect(inputsProviderRegistry.registerInputsProvider).toHaveBeenCalledTimes(1)
+    expect(inputsProviderRegistry.registerInputsProvider).toHaveBeenCalledWith(pageInputsProviderToken)
     expect(messageBus.postMessage).toHaveBeenCalledTimes(2)
     expect(messageBus.postMessage).toHaveBeenNthCalledWith(1, { message: START_GAME_ENGINE_MESSAGE, payload: null })
     expect(messageBus.postMessage).toHaveBeenNthCalledWith(2, { message: SWITCH_PAGE, payload: 'home' })

--- a/tests/engine/managerBuilder.test.ts
+++ b/tests/engine/managerBuilder.test.ts
@@ -8,6 +8,7 @@ import { pageManagerToken } from '@managers/pageManager'
 import { tileSetManagerToken } from '@managers/tileSetManager'
 import { playerPositionManagerToken } from '@managers/playerPositionManager'
 import { turnManagerToken } from '@managers/turnManager'
+import { inputManagerToken } from '@managers/inputManager'
 import { Container } from '@ioc/container'
 import type { Token } from '@ioc/token'
 import type { ILogger } from '@utils/logger'
@@ -37,6 +38,7 @@ describe('managersBuilder', () => {
         playerPositionManagerToken,
         mapManagerToken,
         turnManagerToken,
+        inputManagerToken,
       ].map(String))
     )
   })


### PR DESCRIPTION
## Summary
- account for PageInputsProvider and InputManager in container builder tests
- expect InputManager registration in managers builder
- ensure EngineInitializer test covers new input systems and script action registration

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a217a88ae08332b35d46423b4fa471