### PR TITLE
docs: document script service context and error logging

### DIFF
--- a/engine/services/scriptService.ts
+++ b/engine/services/scriptService.ts
@@ -6,6 +6,23 @@ import { runScript } from '@utils/runScript'
 import { Message } from '@utils/types'
 
 export interface IScriptService {
+    /**
+     * Executes a script within a sandboxed context.
+     *
+     * @template T Return type of the script.
+     * @template U Type of data provided to the script.
+     * @param {string} script Script source to execute.
+     * @param {U} data Input made available to the script.
+     * @returns {T} Value returned by the executed script.
+     *
+     * The script's context exposes the following fields:
+     * - `game`: the current game data.
+     * - `data`: the global game context.
+     * - `postMessage(message)`: dispatches an engine message.
+     *
+     * If execution fails the script, context and data are logged before
+     * rethrowing the error.
+     */
     runScript<T, U>(script: string, data: U): T
 }
 
@@ -19,6 +36,23 @@ export class ScriptService implements IScriptService {
         private messageBus: IMessageBus
     ){}
 
+    /**
+     * Executes a script with the current game context.
+     *
+     * @template T Return type of the script.
+     * @template U Type of data provided to the script.
+     * @param {string} script Script source to execute.
+     * @param {U} data Input made available to the script.
+     * @returns {T} Value returned by the executed script.
+     *
+     * The script's context exposes:
+     * - `game`: the current game data.
+     * - `data`: the global game context.
+     * - `postMessage(message)`: dispatches an engine message.
+     *
+     * If execution fails the script, context and data are logged before
+     * rethrowing the error.
+     */
     public runScript<T, U>(script: string, data: U): T {
         const postMessage = (message: Message<unknown>): void => {
             this.messageBus.postMessage(message)


### PR DESCRIPTION
## Summary
- add full JSDoc for `IScriptService.runScript` and `ScriptService.runScript`
- describe script execution context fields and error logging

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68a22f38744c8332b7fa98345faeaa00