### PR TITLE
Prevent duplicate PlayerPositionManager listeners

### DIFF
--- a/engine/managers/playerPositionManager.ts
+++ b/engine/managers/playerPositionManager.ts
@@ -33,6 +33,7 @@ export class PlayerPositionManager implements IPlayerPositionManager {
     ) { }
 
     public initialize() {
+        this.cleanup()
         this.cleanupFn = this.messageBus.registerMessageListener(
             CHANGE_POSITION,
             message => {

--- a/tests/engine/playerPositionManager.test.ts
+++ b/tests/engine/playerPositionManager.test.ts
@@ -30,3 +30,27 @@ describe('PlayerPositionManager.changePosition', () => {
     })
   })
 })
+
+describe('PlayerPositionManager.initialize', () => {
+  it('clears previous listener on repeated initialization', () => {
+    const cleanup = vi.fn()
+    const register = vi.fn()
+      .mockReturnValueOnce(cleanup)
+      .mockReturnValue(() => {})
+
+    const messageBus = {
+      registerMessageListener: register,
+      postMessage: vi.fn(),
+    } as unknown as IMessageBus
+
+    const provider = {} as unknown as IGameDataProvider
+
+    const manager = new PlayerPositionManager(provider, messageBus)
+
+    manager.initialize()
+    manager.initialize()
+
+    expect(cleanup).toHaveBeenCalledTimes(1)
+    expect(register).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
## Summary
- clean up existing CHANGE_POSITION listener before registering in PlayerPositionManager.initialize
- add test ensuring repeated initialization does not multiply listeners

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68a2344ad4f08332a6c9a3c029d5fff9