### PR TITLE
Refactor input input aggregation to warn on duplicates

### DIFF
--- a/engine/services/inputSourcesService.ts
+++ b/engine/services/inputSourcesService.ts
@@ -3,6 +3,8 @@ import { Token, token } from '@ioc/token'
 import { Input } from '@loader/data/inputs'
 import { ActiveInput, gameDataProviderToken, IGameDataProvider } from '@providers/gameDataProvider'
 import { IInputsProviderRegistry, inputsProviderRegistryToken } from '@registries/inputsProviderRegistry'
+import type { ILogger } from '@utils/logger'
+import { loggerToken } from '@utils/logger'
 
 export interface IInputSourcesService {
     updateInputs(): void
@@ -10,7 +12,7 @@ export interface IInputSourcesService {
 
 const logName = 'InputSourcesService'
 export const inputSourcesServiceToken = token<IInputSourcesService>(logName)
-export const inputSourcesServiceDependencies: Token<unknown>[] = [gameDataProviderToken, conditionResolverToken, inputsProviderRegistryToken]
+export const inputSourcesServiceDependencies: Token<unknown>[] = [gameDataProviderToken, conditionResolverToken, inputsProviderRegistryToken, loggerToken]
 /**
  * Service responsible for gathering inputs from active providers and updating
  * the game's collection of active inputs.
@@ -19,7 +21,8 @@ export class InputSourcesService implements IInputSourcesService {
     constructor(
         private gameDataProvider: IGameDataProvider,
         private conditionResolver: IConditionResolver,
-        private inputsProviderRegistry: IInputsProviderRegistry
+        private inputsProviderRegistry: IInputsProviderRegistry,
+        private logger: ILogger
     ) {}
 
     /**
@@ -28,15 +31,15 @@ export class InputSourcesService implements IInputSourcesService {
      * {@link Game.activeInputs} map with the resolved values.
      */
     public updateInputs(): void {
-        const inputs: Input[] = []
-        this.inputsProviderRegistry.getInputsProviders().forEach(inputsProvider => {
-            if (inputsProvider.isActive()) {
-                inputsProvider.getInputs().forEach(input => inputs.push(input))
-            }
-        })
         const activeInputs = new Map<string, ActiveInput>()
-        inputs.forEach(input => {
-            activeInputs.set(input.virtualInput, this.resolveConditions(input))
+        this.inputsProviderRegistry.getInputsProviders().forEach(inputsProvider => {
+            if (!inputsProvider.isActive()) return
+            inputsProvider.getInputs().forEach(input => {
+                if (activeInputs.has(input.virtualInput)) {
+                    this.logger.warn(logName, 'Duplicate input for virtualInput {0}', input.virtualInput)
+                }
+                activeInputs.set(input.virtualInput, this.resolveConditions(input))
+            })
         })
         this.gameDataProvider.Game.activeInputs = activeInputs
     }

--- a/tests/engine/inputSourcesService.test.ts
+++ b/tests/engine/inputSourcesService.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from 'vitest'
+import { InputSourcesService } from '../../engine/services/inputSourcesService'
+import type { IGameDataProvider, ActiveInput } from '../../engine/providers/gameDataProvider'
+import type { IConditionResolver } from '../../engine/conditions/conditionResolver'
+import type { IInputsProvider, IInputsProviderRegistry } from '../../engine/registries/inputsProviderRegistry'
+import type { ILogger } from '../../utils/logger'
+import type { Input } from '../../engine/loader/data/inputs'
+import type { Condition } from '../../engine/loader/data/condition'
+
+describe('InputSourcesService', () => {
+  it('uses the last provider and warns when duplicate virtualInputs are supplied', () => {
+    const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const conditionResolver: IConditionResolver = {
+      resolve: (condition: Condition | null | undefined) => !!condition && condition.script.endsWith('2')
+    }
+
+    const input1: Input = {
+      virtualInput: 'jump',
+      label: 'Jump1',
+      description: '',
+      visible: { type: 'script', script: 'vis1' },
+      enabled: { type: 'script', script: 'en1' },
+      action: { type: 'noop' }
+    }
+
+    const input2: Input = {
+      virtualInput: 'jump',
+      label: 'Jump2',
+      description: '',
+      visible: { type: 'script', script: 'vis2' },
+      enabled: { type: 'script', script: 'en2' },
+      action: { type: 'noop' }
+    }
+
+    const provider1: IInputsProvider = {
+      isActive: () => true,
+      getInputs: () => [input1]
+    }
+    const provider2: IInputsProvider = {
+      isActive: () => true,
+      getInputs: () => [input2]
+    }
+
+    const registry: IInputsProviderRegistry = {
+      getInputsProviders: () => [provider1, provider2],
+      registerInputsProvider: vi.fn(),
+      clear: vi.fn()
+    }
+
+    const gameData: { activeInputs: Map<string, ActiveInput> } = { activeInputs: new Map() }
+    const gameDataProvider: IGameDataProvider = { Game: gameData } as unknown as IGameDataProvider
+
+    const service = new InputSourcesService(gameDataProvider, conditionResolver, registry, logger)
+    service.updateInputs()
+
+    const result = gameDataProvider.Game.activeInputs.get('jump')
+    expect(result?.input).toBe(input2)
+    expect(result?.enabled).toBe(true)
+    expect(result?.visible).toBe(true)
+    expect(logger.warn).toHaveBeenCalledWith('InputSourcesService', 'Duplicate input for virtualInput {0}', 'jump')
+    expect(logger.warn).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Summary
- Build active input map directly when updating inputs
- Warn when multiple providers supply the same virtual input
- Test input source service to ensure duplicates use last provider and warn

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2348505648332a30e11eee76168bb