### PR TITLE
Render loading placeholder for missing page data

### DIFF
--- a/engine/app/controls/page.tsx
+++ b/engine/app/controls/page.tsx
@@ -12,7 +12,10 @@ interface PageProps {
  */
 export const Page: React.FC<PageProps> = ({ pageId }): React.JSX.Element => {
     const gameDataProvider = useService<IGameDataProvider>(gameDataProviderToken)
-    if (gameDataProvider.Context.currentPageId !== pageId || !gameDataProvider.Game.loadedPages[pageId]) return (<></>)
+    if (gameDataProvider.Context.currentPageId !== pageId || !gameDataProvider.Game.loadedPages[pageId]) {
+        console.warn(`Page ${pageId} is not loaded or is not current. Rendering fallback.`);
+        return (<div>Loading...</div>);
+    }
     const pageData = gameDataProvider.Game.loadedPages[pageId]
 
     return (

--- a/tests/app/Page.test.tsx
+++ b/tests/app/Page.test.tsx
@@ -13,7 +13,7 @@ import { Page } from '@app/controls/page'
 describe('Page', () => {
   beforeEach(() => services.clear())
 
-  it('renders nothing when current page does not match', () => {
+  it('renders fallback when current page does not match', () => {
     const provider = {
       Context: { currentPageId: 'other' },
       Game: { loadedPages: { my: { screen: 'scr' } } }
@@ -21,10 +21,10 @@ describe('Page', () => {
     services.set(gameDataProviderToken, provider)
 
     const { container } = render(<Page pageId='my' />)
-    expect(container.innerHTML).toBe('')
+    expect(container.textContent).toBe('Loading...')
   })
 
-  it('renders nothing when page data is missing', () => {
+  it('renders fallback when page data is missing', () => {
     const provider = {
       Context: { currentPageId: 'my' },
       Game: { loadedPages: {} }
@@ -32,7 +32,7 @@ describe('Page', () => {
     services.set(gameDataProviderToken, provider)
 
     const { container } = render(<Page pageId='my' />)
-    expect(container.innerHTML).toBe('')
+    expect(container.textContent).toBe('Loading...')
   })
 
   it('renders screen for loaded current page', () => {


### PR DESCRIPTION
## Summary
- show a Loading placeholder when a page isn't ready and log a warning
- test Page component fallback behavior

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a25005df7c8332b82ad2d4364d0e6b