### PR TITLE
refactor: use enum for ending turn state

### DIFF
--- a/engine/core/turnScheduler.ts
+++ b/engine/core/turnScheduler.ts
@@ -25,13 +25,11 @@ export interface ITurnScheduler {
  * - `STARTED`: Initial end-of-turn message dispatched, awaiting completion.
  * - `FINALIZING`: Finalization message dispatched; next empty queue completes the turn.
  */
-export const EndingTurnState = {
-    NOT_STARTED: 0,
-    STARTED: 1,
-    FINALIZING: 2
-} as const
-// eslint-disable-next-line no-redeclare
-export type EndingTurnState = typeof EndingTurnState[keyof typeof EndingTurnState]
+export enum EndingTurnState {
+    NOT_STARTED,
+    STARTED,
+    FINALIZING
+}
 
 const logName: string = 'TurnScheduler'
 export const turnSchedulerToken = token<ITurnScheduler>(logName)

--- a/tests/engine/turnScheduler.test.ts
+++ b/tests/engine/turnScheduler.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { TurnScheduler } from '../../engine/core/turnScheduler'
+import { TurnScheduler, EndingTurnState } from '../../engine/core/turnScheduler'
 import { START_END_TURN_MESSAGE, FINALIZE_END_TURN_MESSAGE } from '../../engine/messages/system'
 import type { IMessageBus } from '../../utils/messageBus'
 import type { ILogger } from '@utils/logger'
@@ -10,24 +10,31 @@ describe('TurnScheduler', () => {
     const bus = { postMessage } as unknown as IMessageBus
     const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
     const scheduler = new TurnScheduler(bus, logger)
+    const state = scheduler as unknown as { endingTurn: EndingTurnState }
+
+    expect(state.endingTurn).toBe(EndingTurnState.NOT_STARTED)
 
     // first event: start ending turn
     scheduler.onQueueEmpty()
     expect(postMessage).toHaveBeenCalledTimes(1)
     expect(postMessage).toHaveBeenLastCalledWith({ message: START_END_TURN_MESSAGE, payload: null })
+    expect(state.endingTurn).toBe(EndingTurnState.STARTED)
 
     // second event: finalize turn
     scheduler.onQueueEmpty()
     expect(postMessage).toHaveBeenCalledTimes(2)
     expect(postMessage).toHaveBeenLastCalledWith({ message: FINALIZE_END_TURN_MESSAGE, payload: null })
+    expect(state.endingTurn).toBe(EndingTurnState.FINALIZING)
 
     // third event: no message, reset
     scheduler.onQueueEmpty()
     expect(postMessage).toHaveBeenCalledTimes(2)
+    expect(state.endingTurn).toBe(EndingTurnState.NOT_STARTED)
 
     // fourth event: cycle restarts with start message
     scheduler.onQueueEmpty()
     expect(postMessage).toHaveBeenCalledTimes(3)
     expect(postMessage).toHaveBeenLastCalledWith({ message: START_END_TURN_MESSAGE, payload: null })
+    expect(state.endingTurn).toBe(EndingTurnState.STARTED)
   })
 })


### PR DESCRIPTION
## Summary
- refactor turn scheduler to track ending turn phases with enum instead of object
- update tests to assert state transitions using the enum

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68a2501fbdc0833299a5ab077306d115