### PR TITLE
feat: warn when enabling empty queue at zero

### DIFF
--- a/tests/engine/messageQueue.test.ts
+++ b/tests/engine/messageQueue.test.ts
@@ -122,5 +122,18 @@ describe('MessageQueue', () => {
     expect(handled).toEqual(['a', 'b'])
     expect(onEmpty).toHaveBeenCalledTimes(1)
   })
+
+  it('logs a warning when enableEmptyQueueAfterPost is called at zero', () => {
+    const onEmpty = vi.fn()
+    const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const queue = new MessageQueue(onEmpty, logger)
+
+    queue.enableEmptyQueueAfterPost()
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      'MessageQueue',
+      'enableEmptyQueueAfterPost called but counter is already zero'
+    )
+  })
 })
 

--- a/utils/messageQueue.ts
+++ b/utils/messageQueue.ts
@@ -97,7 +97,11 @@ export class MessageQueue implements IMessageQueue {
      * Decrease the counter and attempt to drain the queue.
      */
     public enableEmptyQueueAfterPost(): void {
-        this.emptyQueueAfterPost = Math.max(0, this.emptyQueueAfterPost - 1)
+        if (this.emptyQueueAfterPost === 0) {
+            this.logger.warn(logName, 'enableEmptyQueueAfterPost called but counter is already zero')
+        } else {
+            this.emptyQueueAfterPost = this.emptyQueueAfterPost - 1
+        }
         void this.emptyQueue()
     }
 


### PR DESCRIPTION
## Summary
- log warning if enableEmptyQueueAfterPost called when counter is zero
- test warning behavior in MessageQueue

## Testing
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a2502ea7a88332b195f08d0e6982d6