### PR TITLE
chore: separate editor Vite config

### DIFF
--- a/editor/vite.config.ts
+++ b/editor/vite.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import { fileURLToPath, URL } from 'node:url'
+import { resolve } from 'node:path'
+
+const rootDir = fileURLToPath(new URL('.', import.meta.url))
+
+export default defineConfig({
+  root: rootDir,
+  envPrefix: ['VITE_', 'LOG_', 'GAME_'],
+  plugins: [
+    react({
+      jsxRuntime: 'automatic',
+    }),
+  ],
+  resolve: {
+    alias: {
+      '@utils': fileURLToPath(new URL('../utils', import.meta.url)),
+      '@ioc': fileURLToPath(new URL('../engine/ioc', import.meta.url)),
+      '@loader/schema': fileURLToPath(new URL('../engine/loader/schema', import.meta.url)),
+    },
+  },
+  build: {
+    rollupOptions: {
+      input: resolve(rootDir, 'editor.html'),
+    },
+  },
+  server: {
+    port: 5174,
+  },
+})

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
         "lint": "eslint .",
         "preview": "vite preview",
         "dev:engine": "vite",
-        "dev:editor": "vite --open editor/editor.html --port 5174"
+        "dev:editor": "vite --config editor/vite.config.ts",
+        "build:editor": "vite build --config editor/vite.config.ts"
     },
     "devDependencies": {
         "@eslint/js": "^9.32.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,6 @@ import { resolve } from 'node:path'
 
 const gameFolder = process.env.GAME_FOLDER || 'sample-game'
 const rootDir = fileURLToPath(new URL('.', import.meta.url))
-const withEditor = process.env.WITH_EDITOR !== 'false'
 
 export default defineConfig({
   envPrefix: ['VITE_', 'LOG_', 'GAME_'],
@@ -25,7 +24,6 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
-      '@editor': fileURLToPath(new URL('./editor', import.meta.url)),
       '@actions': fileURLToPath(new URL('./engine/actions', import.meta.url)),
       '@app': fileURLToPath(new URL('./engine/app', import.meta.url)),
       '@builders': fileURLToPath(new URL('./engine/builders', import.meta.url)),
@@ -46,7 +44,6 @@ export default defineConfig({
     rollupOptions: {
       input: {
         index: resolve(rootDir, 'index.html'),
-        ...(withEditor ? { editor: resolve(rootDir, 'editor/editor.html') } : {}),
       },
     },
   }


### PR DESCRIPTION
## Summary
- add dedicated Vite config for editor with limited aliases
- remove editor alias and build logic from root Vite config
- update scripts to run editor via its own config and add build:editor

## Testing
- `npm run dev` *(engine server on http://localhost:5173)*
- `npm run dev:editor`
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68a42c95c2cc83329b9acd351825b1a5