### PR TITLE
Fix editor server wildcard path for Express 5

### DIFF
--- a/editor/server.ts
+++ b/editor/server.ts
@@ -18,7 +18,7 @@ const safeJoin = (subPath: string): string => {
 
 const relativePath = (p: string) => p.replace(/^\/data\/?/, '')
 
-app.get('/data/*', async (req, res) => {
+app.get('/data/*subPath', async (req, res) => {
   try {
     const filePath = safeJoin(relativePath(req.path))
     const data = await fs.readFile(filePath, 'utf8')
@@ -28,7 +28,7 @@ app.get('/data/*', async (req, res) => {
   }
 })
 
-app.put('/data/*', async (req, res) => {
+app.put('/data/*subPath', async (req, res) => {
   try {
     const filePath = safeJoin(relativePath(req.path))
     await fs.mkdir(path.dirname(filePath), { recursive: true })


### PR DESCRIPTION
## Summary
- handle editor data routes with explicit wildcard parameter to satisfy path-to-regexp

## Testing
- `npm run build`
- `npm run build:editor`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68a49e987c648332aaa2f4891ba6e8ed