### PR TITLE
feat(editor): enable cors middleware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
             "devDependencies": {
                 "@eslint/js": "^9.32.0",
                 "@testing-library/react": "^16.0.0",
+                "@types/cors": "^2.8.19",
                 "@types/express": "^5.0.3",
                 "@types/node": "^24.2.1",
                 "@types/react": "^18.3.3",
@@ -1711,6 +1712,16 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/@types/cors": {
+            "version": "2.8.19",
+            "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+            "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
         "node_modules/@types/deep-eql": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -2756,6 +2767,19 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6.6.0"
+            }
+        },
+        "node_modules/cors": {
+            "version": "2.8.5",
+            "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+            "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+            "license": "MIT",
+            "dependencies": {
+                "object-assign": "^4",
+                "vary": "^1"
+            },
+            "engines": {
+                "node": ">= 0.10"
             }
         },
         "node_modules/cross-env": {
@@ -4306,6 +4330,15 @@
             "integrity": "sha512-o6nIY3qwiSXl7/LuOU0Dmuctd34Yay0yeuZRLFmDPrrdHpXKFndPj3hM+YEPVHYC5fx2otBx4Ilc/gyYSAUaIA==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
         "node_modules/object-inspect": {
             "version": "1.13.4",
@@ -5894,6 +5927,7 @@
             "version": "1.0.0",
             "dependencies": {
                 "@angelabc/shared": "1.0.0",
+                "cors": "^*",
                 "express": "^5.1.0",
                 "react": "^18.3.1",
                 "react-dom": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
         "@eslint/js": "^9.32.0",
         "@testing-library/react": "^16.0.0",
         "@types/express": "^5.0.3",
+        "@types/cors": "^2.8.19",
         "@types/node": "^24.2.1",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "dependencies": {
     "express": "^5.1.0",
+    "cors": "^*",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-icons": "^5.5.0",

--- a/packages/editor/server.ts
+++ b/packages/editor/server.ts
@@ -1,4 +1,5 @@
 import express from 'express'
+import cors from 'cors'
 import { promises as fs } from 'fs'
 import path from 'path'
 
@@ -7,6 +8,7 @@ const resolvedBase = path.resolve(basePath)
 
 const app = express()
 app.use(express.json())
+app.use(cors({ origin: 'http://localhost:5174' }))
 
 const safeJoin = (subPath: string): string => {
   const filePath = path.resolve(resolvedBase, subPath)


### PR DESCRIPTION
## Summary
- add `cors` dependency and middleware for editor server
- include TypeScript types for cors

## Testing
- `npm run build`
- `npm run build:editor`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68a5086bca6483328efe5664f2f6a3fb