### PR TITLE
feat(editor): load environment variables via dotenv

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
                 "@vitejs/plugin-react": "^4.3.1",
                 "concurrently": "^9.2.0",
                 "cross-env": "^10.0.0",
+                "dotenv": "^16.4.5",
                 "eslint": "9.33.0",
                 "express": "^5.1.0",
                 "globals": "^16.3.0",
@@ -2918,6 +2919,19 @@
             "dev": true,
             "license": "MIT",
             "peer": true
+        },
+        "node_modules/dotenv": {
+            "version": "16.6.1",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+            "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://dotenvx.com"
+            }
         },
         "node_modules/dunder-proto": {
             "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "devDependencies": {
         "@eslint/js": "^9.32.0",
         "@testing-library/react": "^16.0.0",
-        "@types/express": "^5.0.3",
         "@types/cors": "^2.8.19",
+        "@types/express": "^5.0.3",
         "@types/node": "^24.2.1",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
@@ -34,6 +34,7 @@
         "@vitejs/plugin-react": "^4.3.1",
         "concurrently": "^9.2.0",
         "cross-env": "^10.0.0",
+        "dotenv": "^16.4.5",
         "eslint": "9.33.0",
         "express": "^5.1.0",
         "globals": "^16.3.0",

--- a/packages/editor/server.ts
+++ b/packages/editor/server.ts
@@ -1,10 +1,12 @@
+import 'dotenv/config'
 import express from 'express'
 import cors from 'cors'
 import { promises as fs } from 'fs'
 import path from 'path'
 
-const basePath = process.env.VITE_DATA_PATH ?? '/data'
+const basePath = process.env.GAME_DIR ?? process.env.VITE_DATA_PATH ?? '/data'
 const resolvedBase = path.resolve(basePath)
+console.log(`Serving data from ${resolvedBase}`)
 
 const app = express()
 app.use(express.json())


### PR DESCRIPTION
## Summary
- use dotenv to load environment variables for editor server
- allow GAME_DIR or VITE_DATA_PATH to configure data directory

## Testing
- `npm run build`
- `npm run build:editor`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68a59d0efc548332a3870d246215a3b1