### PR TITLE
refactor: isolate editor and engine tsconfigs

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,12 +13,12 @@
     "license": "MPL-2.0",
     "type": "module",
     "scripts": {
-        "dev": "concurrently -n \"vite,tsc\" \"vite\" \"tsc --noEmit --watch\"",
+        "dev": "concurrently -n \"vite,tsc\" \"vite\" \"tsc -p packages/engine/tsconfig.json --noEmit --watch\"",
         "dev:editor": "concurrently -n \"vite,server\" \"vite --config packages/editor/vite.config.ts\" \"node packages/editor/server.ts\"",
         "test": "vitest run",
         "test:dev": "vitest watch",
         "lint": "eslint .",
-        "build": "tsc && vite build",
+        "build": "tsc -p packages/engine/tsconfig.json && vite build",
         "build:editor": "vite build --config packages/editor/vite.config.ts"
     },
     "devDependencies": {

--- a/packages/editor/tsconfig.json
+++ b/packages/editor/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "paths": {
+      "@editor/*": ["./*"],
+      "@utils/*": ["../shared/utils/*"],
+      "@ioc/*": ["../shared/ioc/*"],
+      "@loader/schema/*": ["../shared/loader/schema/*"]
+    }
+  },
+  "include": ["./**/*"]
+}

--- a/packages/engine/tsconfig.json
+++ b/packages/engine/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "paths": {
+      "@actions/*": ["./actions/*"],
+      "@app/*": ["./app/*"],
+      "@builders/*": ["./builders/*"],
+      "@conditions/*": ["./conditions/*"],
+      "@core/*": ["./core/*"],
+      "@inputs/*": ["./inputs/*"],
+      "@loader/*": ["./loader/*"],
+      "@managers/*": ["./managers/*"],
+      "@messages/*": ["./messages/*"],
+      "@providers/*": ["./providers/*"],
+      "@registries/*": ["./registries/*"],
+      "@services/*": ["./services/*"],
+      "@utils/*": ["../shared/utils/*"],
+      "@ioc/*": ["../shared/ioc/*"],
+      "@loader/schema/*": ["../shared/loader/schema/*"]
+    }
+  },
+  "include": ["./**/*"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "jsx": "react-jsx",
+    "noEmit": true,
+    "types": ["vite/client", "node"],
+    "paths": {
+      "@utils/*": ["./packages/shared/utils/*"],
+      "@ioc/*": ["./packages/shared/ioc/*"],
+      "@loader/schema/*": ["./packages/shared/loader/schema/*"]
+    }
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,31 +1,3 @@
 {
-  "compilerOptions": {
-    "target": "ESNext",
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
-    "strict": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "skipLibCheck": true,
-    "jsx": "react-jsx",
-    "noEmit": true,
-    "paths": {
-      "@editor/*": ["./packages/editor/*"],
-      "@actions/*": ["./packages/engine/actions/*"],
-      "@app/*": ["./packages/engine/app/*"],
-      "@builders/*": ["./packages/engine/builders/*"],
-      "@conditions/*": ["./packages/engine/conditions/*"],
-      "@core/*": ["./packages/engine/core/*"],
-      "@inputs/*": ["./packages/engine/inputs/*"],
-      "@ioc/*": ["./packages/shared/ioc/*"],
-      "@loader/schema/*": ["./packages/shared/loader/schema/*"],
-      "@loader/*": ["./packages/engine/loader/*"],
-      "@managers/*": ["./packages/engine/managers/*"],
-      "@messages/*": ["./packages/engine/messages/*"],
-      "@providers/*": ["./packages/engine/providers/*"],
-      "@registries/*": ["./packages/engine/registries/*"],
-      "@services/*": ["./packages/engine/services/*"],
-      "@utils/*": ["./packages/shared/utils/*"]
-    }
-  }
+  "extends": "./tsconfig.base.json"
 }


### PR DESCRIPTION
## Summary
- add shared `tsconfig.base.json` for common options and shared aliases
- move engine and editor path aliases into package-level tsconfigs
- update dev/build scripts to compile using engine tsconfig

## Testing
- `npm run lint`
- `npm run build`
- `npm run build:editor`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68a5a9b01a3c8332aeb9df67c04c0b07