### PR TITLE
Toggle collapsing in editor tree nodes

### DIFF
--- a/packages/editor/app/treeNode.tsx
+++ b/packages/editor/app/treeNode.tsx
@@ -1,18 +1,28 @@
 import { GameItemTreeNode } from '@editor/providers/editTreeProvider'
 import { AiTwotoneFolder, AiTwotoneFolderOpen } from 'react-icons/ai'
+import { useState } from 'react'
 
 interface TreeNodeProps {
     node: GameItemTreeNode
 }
 
 export const TreeNode: React.FC<TreeNodeProps> = ({ node }): React.JSX.Element => {
-    const icon = node.isCollapsed ? <AiTwotoneFolder /> : <AiTwotoneFolderOpen />
+    const [isCollapsed, setIsCollapsed] = useState<boolean>(node.isCollapsed)
+    const icon = isCollapsed ? <AiTwotoneFolder /> : <AiTwotoneFolderOpen />
+
+    const toggle = (): void => {
+        if (node.children.length === 0) return
+        const newValue = !isCollapsed
+        node.isCollapsed = newValue
+        setIsCollapsed(newValue)
+    }
+
     return (
         <div>
-            <label>{icon} {node.label}</label>
-            {!node.isCollapsed && node.children.length > 0 && (
+            <label onClick={toggle}>{icon} {node.label}</label>
+            {!isCollapsed && node.children.length > 0 && (
                 <div className='children'>
-                    {node.children.map(child => <TreeNode node={child} />)}
+                    {node.children.map(child => <TreeNode node={child} key={child.label} />)}
                 </div>
             )}
         </div>

--- a/packages/editor/main.tsx
+++ b/packages/editor/main.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import { App } from './app/app'
+import { App } from './app/App'
 import { ContainerBuilder, IContainerBuilder } from './builders/containerBuilder'
 import { ConsoleLogger } from '@utils/logger'
 import { IocProvider } from '@ioc/iocProvider'


### PR DESCRIPTION
## Summary
- Toggle tree nodes' `isCollapsed` when clicking labels with children
- Fix editor App import casing for build

## Testing
- `npm run build`
- `npm run build:editor`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68a73c81ac0c8332a1825f4d1addaacd