### PR TITLE
fix: add messageBus to content effect dependencies

### DIFF
--- a/packages/editor/app/content.tsx
+++ b/packages/editor/app/content.tsx
@@ -21,7 +21,7 @@ export const Content: React.FC = (): React.JSX.Element => {
                 setContentInfo(message.payload as ContentInfo)
             }
         )
-    }, [])
+    }, [messageBus, setContentInfo])
     return (
         <section className='main'>
             <ContentBar />


### PR DESCRIPTION
## Summary
- include messageBus and setter in Content effect deps to satisfy lint

## Testing
- `npm run build`
- `npm run build:editor`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68a77f1dfba4833289b57e62fc7131d5