### PR TITLE
refactor: centralize editor tests

### DIFF
--- a/tests/editor/editTreeProvider.test.ts
+++ b/tests/editor/editTreeProvider.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
-import { EditTreeProvider } from './editTreeProvider'
-import { IGameDefinitionProvider, GameItem, RootItem, PageItem, LanguageItem } from './gameDefinitionProvider'
+import { EditTreeProvider } from '../../packages/editor/providers/editTreeProvider'
+import { IGameDefinitionProvider, GameItem, RootItem, PageItem, LanguageItem } from '../../packages/editor/providers/gameDefinitionProvider'
 import type { ILogger } from '@utils/logger'
 import type { Game } from '@loader/schema/game'
 


### PR DESCRIPTION
## Summary
- move EditTreeProvider test from package into central tests folder

## Testing
- `npm run build`
- `npm run build:editor`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68a78b10a820833285bd477588073049