### PR TITLE
fix: correct item definitions type reference

### DIFF
--- a/packages/editor/providers/gameDefinitionProvider.ts
+++ b/packages/editor/providers/gameDefinitionProvider.ts
@@ -39,7 +39,7 @@ export type StylingItem = BaseFileItem<string> & { type: 'styling' }
 export type VirtualKeysItem = BaseFileItem<VirtualKeys> & { type: 'virtual-keys' }
 export type VirtualInputsItem = BaseFileItem<VirtualInputs> & { type: 'virtual-inputs' }
 export type TagsItem = BaseFileItem<Tags> & { type: 'tags' }
-export type ItemDefinitionsItem = BaseFileItem<ItemDefinitions> & { type: 'item-definions' }
+export type ItemDefinitionsItem = BaseFileItem<ItemDefinitions> & { type: 'item-definitions' }
 
 export type GameItem = RootItem | PageItem | ActionsItem | LanguageItem | MapItem
     | TileItem | DialogItem | StylingItem | VirtualInputsItem | VirtualKeysItem
@@ -172,7 +172,7 @@ export class GameDefinitionProvider implements IGameDefinitionProvider {
     private addItemDefinitions(root: Game): void {
         this.addArrayItems<ItemDefinitionsItem>(root['item-definitions'], (id, filename) => ({
             id,
-            type: 'item-definions',
+            type: 'item-definitions',
             current: null,
             original: null,
             currentFilename: filename,

--- a/tests/editor/gameDefinitionProvider.test.ts
+++ b/tests/editor/gameDefinitionProvider.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { GameDefinitionProvider } from '../../packages/editor/providers/gameDefinitionProvider'
+import type { Game } from '@loader/schema/game'
+
+
+describe('GameDefinitionProvider', () => {
+    it('categorizes item-definitions records', () => {
+        const provider = new GameDefinitionProvider()
+        const game: Game = {
+            title: 'Test',
+            description: 'desc',
+            version: '1',
+            'initial-data': { language: 'en', 'start-page': 'start' },
+            languages: {},
+            pages: {},
+            maps: {},
+            tiles: {},
+            dialogs: {},
+            styling: [],
+            actions: [],
+            'virtual-keys': [],
+            'virtual-inputs': [],
+            tags: [],
+            'item-definitions': [
+                'item-definitions/b.json',
+                'item-definitions/a.json'
+            ]
+        }
+        provider.setRoot(game)
+        const items = provider.Items.filter(i => i.type === 'item-definitions')
+        expect(items.map(i => i.currentFilename)).toEqual([
+            'item-definitions/a.json',
+            'item-definitions/b.json'
+        ])
+    })
+})


### PR DESCRIPTION
## Summary
- fix ItemDefinitions type literal typo
- test GameDefinitionProvider handles item-definitions records

## Testing
- `npm run build`
- `npm run build:editor`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68a79e794f1083328507470fd4f50ba1