### PR TITLE
feat(editor): configurable data url for game definition loader

### DIFF
--- a/packages/editor/builders/containerBuilder.ts
+++ b/packages/editor/builders/containerBuilder.ts
@@ -1,6 +1,6 @@
 import { Editor, editorDependencies, editorToken } from '@editor/core/editor'
 import { EditorInitializer, editorInitializerDependencies, editorInitializerToken } from '@editor/core/editorInitializer'
-import { GameDefinitionLoaderManager, gameDefinitionLoaderManagerDependencies, gameDefinitionLoaderManagerToken } from '@editor/managers/gameDefinitionManager'
+import { GameDefinitionLoaderManager, gameDefinitionLoaderManagerDependencies, gameDefinitionLoaderManagerToken, dataUrlToken } from '@editor/managers/gameDefinitionManager'
 import { EditTreeProvider, editTreeProviderDependencies, editTreeProviderToken } from '@editor/providers/editTreeProvider'
 import { GameDefinitionProvider, gameDefinitionProviderDependencies, gameDefinitionProviderToken } from '@editor/providers/gameDefinitionProvider'
 import { Container } from '@ioc/container'
@@ -14,7 +14,8 @@ export interface IContainerBuilder {
 
 export class ContainerBuilder implements IContainerBuilder {
     constructor(
-        private loggerFactory: () => ILogger
+        private loggerFactory: () => ILogger,
+        private dataUrl: string
     ) { }
 
     public build(): Container {
@@ -42,6 +43,10 @@ export class ContainerBuilder implements IContainerBuilder {
             token: editorInitializerToken,
             useClass: EditorInitializer,
             deps: editorInitializerDependencies
+        })
+        result.register({
+            token: dataUrlToken,
+            useValue: this.dataUrl
         })
         result.register({
             token: gameDefinitionLoaderManagerToken,

--- a/packages/editor/main.tsx
+++ b/packages/editor/main.tsx
@@ -11,7 +11,8 @@ import './styling/variables.css'
 import './styling/editor.css'
 
 const containerBuilder: IContainerBuilder = new ContainerBuilder(
-  () => new ConsoleLogger()
+  () => new ConsoleLogger(),
+  import.meta.env.VITE_DATA_URL ?? 'http://localhost:3000/data'
 )
 const container: Container = containerBuilder.build()
 

--- a/packages/editor/managers/gameDefinitionManager.ts
+++ b/packages/editor/managers/gameDefinitionManager.ts
@@ -5,7 +5,7 @@ import { ILogger, loggerToken } from '@utils/logger'
 import { IMessageBus, messageBusToken } from '@utils/messageBus'
 import { CleanUp } from '@utils/types'
 import { GAME_DEFINITION_UPDATED, INITIALIZED } from '../messages/editor'
-import { gameDefinitionProviderToken, IGameDefinitionProvider } from '@editor/providers/gameDefinitionProvider'
+import { gameDefinitionProviderToken, IGameDefinitionProvider } from '../providers/gameDefinitionProvider'
 
 export interface IGameDefinitionLoaderManager {
     initialize(): void
@@ -14,13 +14,20 @@ export interface IGameDefinitionLoaderManager {
 
 const logName = 'GameDefinitionLoaderManager'
 export const gameDefinitionLoaderManagerToken = token<IGameDefinitionLoaderManager>(logName)
-export const gameDefinitionLoaderManagerDependencies: Token<unknown>[] = [loggerToken, messageBusToken, gameDefinitionProviderToken]
+export const dataUrlToken = token<string>('dataUrl')
+export const gameDefinitionLoaderManagerDependencies: Token<unknown>[] = [
+    loggerToken,
+    messageBusToken,
+    gameDefinitionProviderToken,
+    dataUrlToken
+]
 export class GameDefinitionLoaderManager implements IGameDefinitionLoaderManager {
     private cleanupFn: CleanUp | null = null
     constructor(
         private logger: ILogger,
         private messageBus: IMessageBus,
-        private gameDefinitionProvider: IGameDefinitionProvider
+        private gameDefinitionProvider: IGameDefinitionProvider,
+        private dataUrl: string
     ){}
 
     public cleanup(): void {
@@ -38,7 +45,7 @@ export class GameDefinitionLoaderManager implements IGameDefinitionLoaderManager
     }
 
     private async onInitialized(): Promise<void> {
-        const game = await loadJsonResource<Game>('http://localhost:3000/data/index.json', gameSchema, this.logger)
+        const game = await loadJsonResource<Game>(`${this.dataUrl}/index.json`, gameSchema, this.logger)
         this.gameDefinitionProvider.setRoot(game)
         this.messageBus.postMessage({
             message: GAME_DEFINITION_UPDATED,

--- a/tests/editor/gameDefinitionManager.test.ts
+++ b/tests/editor/gameDefinitionManager.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, Mock } from 'vitest'
+
+vi.mock('@utils/loadJsonResource', () => ({ loadJsonResource: vi.fn() }))
+
+import { loadJsonResource } from '@utils/loadJsonResource'
+import { GameDefinitionLoaderManager } from '../../packages/editor/managers/gameDefinitionManager'
+import { INITIALIZED } from '../../packages/editor/messages/editor'
+import type { ILogger } from '@utils/logger'
+import type { IMessageBus } from '@utils/messageBus'
+import type { IGameDefinitionProvider } from '../../packages/editor/providers/gameDefinitionProvider'
+
+// simple mock provider
+class MockGameDefinitionProvider implements IGameDefinitionProvider {
+  public get Items() { return [] }
+  public setRoot = vi.fn()
+}
+
+describe('GameDefinitionLoaderManager', () => {
+  it('loads from provided data url', async () => {
+    const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const provider = new MockGameDefinitionProvider()
+
+    const listeners: Record<string, (msg: unknown) => unknown> = {}
+    const messageBus: IMessageBus = {
+      postMessage: vi.fn(),
+      registerMessageListener: vi.fn((msg, handler) => {
+        listeners[msg] = handler
+        return () => delete listeners[msg]
+      }),
+      registerNotificationMessage: vi.fn(),
+      unregisterNotificationMessage: vi.fn(),
+      disableEmptyQueueAfterPost: vi.fn(),
+      enableEmptyQueueAfterPost: vi.fn(),
+      shutDown: vi.fn()
+    } as unknown as IMessageBus
+
+    ;(loadJsonResource as unknown as Mock).mockResolvedValue({})
+
+    const manager = new GameDefinitionLoaderManager(logger, messageBus, provider, '/base')
+    manager.initialize()
+
+    await (listeners[INITIALIZED] as (msg: unknown) => Promise<void>)({ message: INITIALIZED, payload: null })
+
+    expect(loadJsonResource).toHaveBeenCalledWith('/base/index.json', expect.anything(), logger)
+  })
+})


### PR DESCRIPTION
## Summary
- make game definition loader base URL configurable via `dataUrlToken`
- inject `VITE_DATA_URL` into editor container
- ensure loader uses injected URL with unit test

## Testing
- `npm run lint`
- `npm run build`
- `npm run build:editor`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68a79ec2c9d48332a9c977f296f93fe7