### PR TITLE
feat(editor): allow server CORS origin to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ The server reads from `VITE_DATA_PATH` (defaults to `/data`) and exposes:
 - `GET /data/*` - return the JSON content of the requested file
 - `PUT /data/*` - write the request body as JSON to the file
 
+`VITE_EDITOR_ORIGIN` may be set to configure the allowed CORS origin for the server. It defaults to `http://localhost:5174`.
+
 ## Testing and Build Commands
 Run the following commands before submitting changes:
 

--- a/packages/editor/server.ts
+++ b/packages/editor/server.ts
@@ -11,42 +11,50 @@ const basePath = process.env.GAME_DIR ?? process.env.VITE_DATA_PATH ?? '/data'
 const resolvedBase = path.resolve(basePath)
 console.log(`Serving data from ${resolvedBase}`)
 
-const app = express()
-app.use(express.json())
-app.use(cors({ origin: 'http://localhost:5174' }))
+export const createServer = () => {
+  const app = express()
+  app.use(express.json())
 
-const safeJoin = (subPath: string): string => {
-  const filePath = path.resolve(resolvedBase, subPath)
-  if (!filePath.startsWith(resolvedBase + path.sep) && filePath !== resolvedBase) {
-    throw new Error('Invalid path')
+  const allowedOrigin = process.env.VITE_EDITOR_ORIGIN ?? 'http://localhost:5174'
+  app.use(cors({ origin: allowedOrigin }))
+
+  const safeJoin = (subPath: string): string => {
+    const filePath = path.resolve(resolvedBase, subPath)
+    if (!filePath.startsWith(resolvedBase + path.sep) && filePath !== resolvedBase) {
+      throw new Error('Invalid path')
+    }
+    return filePath
   }
-  return filePath
+
+  const relativePath = (p: string) => p.replace(/^\/data\/?/, '')
+
+  app.get('/data/*subPath', async (req, res) => {
+    try {
+      const filePath = safeJoin(relativePath(req.path))
+      const data = await fs.readFile(filePath, 'utf8')
+      res.json(JSON.parse(data))
+    } catch {
+      res.sendStatus(404)
+    }
+  })
+
+  app.put('/data/*subPath', async (req, res) => {
+    try {
+      const filePath = safeJoin(relativePath(req.path))
+      await fs.mkdir(path.dirname(filePath), { recursive: true })
+      await fs.writeFile(filePath, JSON.stringify(req.body, null, 2))
+      res.sendStatus(204)
+    } catch {
+      res.sendStatus(500)
+    }
+  })
+
+  return app
 }
 
-const relativePath = (p: string) => p.replace(/^\/data\/?/, '')
-
-app.get('/data/*subPath', async (req, res) => {
-  try {
-    const filePath = safeJoin(relativePath(req.path))
-    const data = await fs.readFile(filePath, 'utf8')
-    res.json(JSON.parse(data))
-  } catch {
-    res.sendStatus(404)
-  }
-})
-
-app.put('/data/*subPath', async (req, res) => {
-  try {
-    const filePath = safeJoin(relativePath(req.path))
-    await fs.mkdir(path.dirname(filePath), { recursive: true })
-    await fs.writeFile(filePath, JSON.stringify(req.body, null, 2))
-    res.sendStatus(204)
-  } catch {
-    res.sendStatus(500)
-  }
-})
-
-const port = 3000
-app.listen(port, () => {
-  console.log(`Server listening on port ${port}`)
-})
+if (process.env.NODE_ENV !== 'test') {
+  const port = 3000
+  createServer().listen(port, () => {
+    console.log(`Server listening on port ${port}`)
+  })
+}

--- a/tests/editor/server.test.ts
+++ b/tests/editor/server.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import type { AddressInfo } from 'net'
+import { createServer } from '../../packages/editor/server'
+
+const request = async (origin?: string) => {
+  const app = createServer()
+  const server = app.listen(0)
+  const { port } = server.address() as AddressInfo
+  const res = await fetch(`http://localhost:${port}/data/whatever`, {
+    headers: origin ? { Origin: origin } : {}
+  })
+  server.close()
+  return res
+}
+
+describe('editor server CORS', () => {
+  afterEach(() => {
+    delete process.env.VITE_EDITOR_ORIGIN
+  })
+
+  it('uses default origin when not configured', async () => {
+    const res = await request('http://localhost:5174')
+    expect(res.headers.get('access-control-allow-origin')).toBe('http://localhost:5174')
+  })
+
+  it('applies configured origin', async () => {
+    process.env.VITE_EDITOR_ORIGIN = 'https://example.com'
+    const res = await request('https://example.com')
+    expect(res.headers.get('access-control-allow-origin')).toBe('https://example.com')
+  })
+})


### PR DESCRIPTION
## Summary
- allow editor server to read CORS origin from `VITE_EDITOR_ORIGIN` with default
- document `VITE_EDITOR_ORIGIN` and add tests for server CORS configuration

## Testing
- `npm run build`
- `npm run build:editor`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68a7a1dc0ca48332be96f83fd232e165