### PR TITLE
Refactor editor TreeNode state management and add tests

### DIFF
--- a/packages/editor/app/treeNode.tsx
+++ b/packages/editor/app/treeNode.tsx
@@ -17,9 +17,7 @@ export const TreeNode: React.FC<TreeNodeProps> = ({ node }): React.JSX.Element =
 
     const toggle = (): void => {
         if (!hasChildren) return
-        const newValue = !isCollapsed
-        node.isCollapsed = newValue
-        setIsCollapsed(newValue)
+        setIsCollapsed(prev => !prev)
     }
 
     const select = (): void => {
@@ -35,7 +33,15 @@ export const TreeNode: React.FC<TreeNodeProps> = ({ node }): React.JSX.Element =
 
     return (
         <div>
-            <label><span onClick={toggle}>{icon}</span> <span onClick={select}>{node.label}</span></label>
+            <label>
+                {hasChildren && (
+                    <button type='button' onClick={toggle} aria-label='toggle'>
+                        {icon}
+                    </button>
+                )}
+                {' '}
+                <button type='button' onClick={select}>{node.label}</button>
+            </label>
             {!isCollapsed && hasChildren && (
                 <div className='children'>
                     {node.children.map(child => <TreeNode node={child} key={child.data?.id ?? child.label} />)}

--- a/tests/editor/treeNode.test.tsx
+++ b/tests/editor/treeNode.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { services } from '../app/testUtils'
+import { TreeNode } from '../../packages/editor/app/treeNode'
+import { messageBusToken, type IMessageBus } from '@utils/messageBus'
+import { SET_EDITOR_CONTENT } from '../../packages/editor/messages/editor'
+import type { GameItemTreeNode } from '../../packages/editor/providers/editTreeProvider'
+import { afterEach } from 'vitest'
+
+const createNode = (): GameItemTreeNode => ({
+    label: 'parent',
+    children: [{ label: 'child', children: [], isCollapsed: false, data: null, level: 1 }],
+    isCollapsed: false,
+    data: null,
+    level: 0
+})
+
+describe('TreeNode', () => {
+    beforeEach(() => services.clear())
+    afterEach(() => cleanup())
+
+    it('toggles collapse state without mutating node', async () => {
+        const node = createNode()
+        const messageBus = { postMessage: vi.fn() } as unknown as IMessageBus
+        services.set(messageBusToken, messageBus)
+
+        render(<TreeNode node={node} />)
+
+        const toggleButton = screen.getByRole('button', { name: 'toggle' })
+        expect(screen.queryByText('child')).not.toBeNull()
+
+        fireEvent.click(toggleButton)
+        expect(screen.queryByText('child')).toBeNull()
+        expect(node.isCollapsed).toBe(false)
+
+        fireEvent.click(toggleButton)
+        expect(screen.queryByText('child')).not.toBeNull()
+        expect(node.isCollapsed).toBe(false)
+    })
+
+    it('posts selection message without mutating node', async () => {
+        const node = createNode()
+        const postMessage = vi.fn()
+        services.set(messageBusToken, { postMessage } as unknown as IMessageBus)
+
+        render(<TreeNode node={node} />)
+
+        const selectButton = screen.getByRole('button', { name: 'parent' })
+        fireEvent.click(selectButton)
+
+        expect(postMessage).toHaveBeenCalledWith({
+            message: SET_EDITOR_CONTENT,
+            payload: { label: 'parent', level: 0, data: null }
+        })
+        expect(node.isCollapsed).toBe(false)
+    })
+})
+

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+import { fileURLToPath, URL } from 'node:url'
+
+export default defineConfig({
+  plugins: [react({ jsxRuntime: 'automatic' })],
+  resolve: {
+    alias: {
+      '@actions': fileURLToPath(new URL('./packages/engine/actions', import.meta.url)),
+      '@app': fileURLToPath(new URL('./packages/engine/app', import.meta.url)),
+      '@builders': fileURLToPath(new URL('./packages/engine/builders', import.meta.url)),
+      '@conditions': fileURLToPath(new URL('./packages/engine/conditions', import.meta.url)),
+      '@core': fileURLToPath(new URL('./packages/engine/core', import.meta.url)),
+      '@ioc': fileURLToPath(new URL('./packages/shared/ioc', import.meta.url)),
+      '@inputs': fileURLToPath(new URL('./packages/engine/inputs', import.meta.url)),
+      '@loader/schema': fileURLToPath(new URL('./packages/shared/loader/schema', import.meta.url)),
+      '@loader': fileURLToPath(new URL('./packages/engine/loader', import.meta.url)),
+      '@managers': fileURLToPath(new URL('./packages/engine/managers', import.meta.url)),
+      '@messages': fileURLToPath(new URL('./packages/engine/messages', import.meta.url)),
+      '@providers': fileURLToPath(new URL('./packages/engine/providers', import.meta.url)),
+      '@registries': fileURLToPath(new URL('./packages/engine/registries', import.meta.url)),
+      '@services': fileURLToPath(new URL('./packages/engine/services', import.meta.url)),
+      '@utils': fileURLToPath(new URL('./packages/shared/utils', import.meta.url)),
+      '@editor': fileURLToPath(new URL('./packages/editor', import.meta.url)),
+    }
+  }
+})


### PR DESCRIPTION
## Summary
- avoid mutating incoming tree nodes and manage collapse via React state
- swap span click targets for buttons to improve accessibility
- test tree node toggle and selection without prop mutation
- add Vitest config with editor alias for testing

## Testing
- `npm run build`
- `npm run build:editor`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68a7a19030a0833281a0c9020a2aad34