### PR TITLE
Fix editor tests and language grouping

### DIFF
--- a/packages/editor/providers/editTreeProvider.ts
+++ b/packages/editor/providers/editTreeProvider.ts
@@ -65,7 +65,7 @@ export class EditTreeProvider implements IEditTreeProvider {
                 result.push(parentNode)
                 nodeLookup.set(item.type, parentNode)
             }
-            if (item.type === 'languages') {
+            if (item.type === 'language') {
                 let languageRootNode: GameItemTreeNode
                 if (nodeLookup.has(item.currentKey)) languageRootNode = nodeLookup.get(item.currentKey)!
                 else {

--- a/tests/editor/gameDefinitionLoaderManager.test.ts
+++ b/tests/editor/gameDefinitionLoaderManager.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, Mock } from 'vitest'
 vi.mock('@utils/loadJsonResource', () => ({ loadJsonResource: vi.fn() }))
 
 import { loadJsonResource } from '@utils/loadJsonResource'
-import { GameDefinitionLoaderManager } from '../../packages/editor/managers/gameDefinitionManager'
+import { GameDefinitionLoaderManager } from '../../packages/editor/managers/gameDefinitionLoaderManager'
 import { INITIALIZED } from '../../packages/editor/messages/editor'
 import type { ILogger } from '@utils/logger'
 import type { IMessageBus } from '@utils/messageBus'


### PR DESCRIPTION
## Summary
- update GameDefinitionLoaderManager test import to new path
- correct language grouping in EditTreeProvider

## Testing
- `npm run build`
- `npm run build:editor`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8be34d088833283f7bf0219515d4a