### PR TITLE
fix: correct InputMatrix interface naming

### DIFF
--- a/packages/engine/app/controls/component/inputMatrix.tsx
+++ b/packages/engine/app/controls/component/inputMatrix.tsx
@@ -1,18 +1,18 @@
 import { useService } from '@ioc/iocProvider'
 import { CSSCustomProperties } from '@app/types'
-import { IInputMatrxBuilder, inputMatrixBuilderToken, MatrixInputItem } from '@builders/inputMatrixBuilder'
+import { IInputMatrixBuilder, inputMatrixBuilderToken, MatrixInputItem } from '@builders/inputMatrixBuilder'
 import { InputMatrixComponent } from '@loader/data/component'
 import { FINALIZE_END_TURN_MESSAGE, VIRTUAL_INPUT } from '@messages/system'
 import { IMessageBus, messageBusToken } from '@utils/messageBus'
 import { useEffect, useState } from 'react'
 
-export type InputMatrxProps = {
+export type InputMatrixProps = {
     component: InputMatrixComponent
 }
 
-export const InputMatrix: React.FC<InputMatrxProps> = ({ component }): React.JSX.Element => {
+export const InputMatrix: React.FC<InputMatrixProps> = ({ component }): React.JSX.Element => {
     const messageBus = useService<IMessageBus>(messageBusToken)
-    const inputMatrixBuilder = useService<IInputMatrxBuilder>(inputMatrixBuilderToken)
+    const inputMatrixBuilder = useService<IInputMatrixBuilder>(inputMatrixBuilderToken)
     const [inputMatrix, setInputMatrix] = useState(inputMatrixBuilder.build(component.matrixSize.width, component.matrixSize.height))
 
     const style: CSSCustomProperties = {

--- a/packages/engine/builders/inputMatrixBuilder.ts
+++ b/packages/engine/builders/inputMatrixBuilder.ts
@@ -19,17 +19,17 @@ export const nullMatrixInputItem: MatrixInputItem = {
     character: ''
 }
 
-export interface IInputMatrxBuilder {
+export interface IInputMatrixBuilder {
     build(width: number, height: number): MatrixInputItem[][]
 }
 
 const logName = 'InputMatrixBuilder'
-export const inputMatrixBuilderToken = token<IInputMatrxBuilder>(logName)
+export const inputMatrixBuilderToken = token<IInputMatrixBuilder>(logName)
 export const inputMatrixBuilderDependencies: Token<unknown>[] = [
     gameDataProviderToken,
     translationServiceToken
 ]
-export class InputMatrixBuilder implements IInputMatrxBuilder {
+export class InputMatrixBuilder implements IInputMatrixBuilder {
     constructor(
         private gameDataProvider: IGameDataProvider,
         private translationService: ITranslationService


### PR DESCRIPTION
## Summary
- rename IInputMatrxBuilder to IInputMatrixBuilder
- update component props to InputMatrixProps

## Testing
- `npm run build`
- `npm run build:editor`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68aac069d7bc8332b746c6b69165be11