### PR TITLE
fix: make core initializer synchronous

### DIFF
--- a/packages/engine/core/initializers/coreInitializer.ts
+++ b/packages/engine/core/initializers/coreInitializer.ts
@@ -40,7 +40,7 @@ export class CoreInitializer implements ICoreInitializer {
      *
      * @param game The game metadata defining title and CSS files.
      */
-    public async initialize(game: Game): Promise<void> {
+    public initialize(game: Game): void {
         this.setupBrowser(game)
     }
 


### PR DESCRIPTION
## Summary
- make CoreInitializer.initialize synchronous

## Testing
- `npm run build`
- `npm run build:editor`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68aacb11dd788332b4f026a32a5928b7