### PR TITLE
fix: rename GoToDialog action

### DIFF
--- a/packages/engine/actions/goToDialog.ts
+++ b/packages/engine/actions/goToDialog.ts
@@ -6,12 +6,12 @@ import { ITranslationService, translationServiceToken } from '@services/translat
 import { IMessageBus, messageBusToken } from '@utils/messageBus'
 import { Message } from '@utils/types'
 
-export type IGotoDialog = IActionHandler<GotoDialogAction>
+export type IGoToDialog = IActionHandler<GotoDialogAction>
 
-const logName = 'GotoDialog'
-export const gotoDialogToken = token<IGotoDialog>(logName)
-export const gotoDialogDependencies: Token<unknown>[] = [messageBusToken, translationServiceToken]
-export class GotoDialog implements IGotoDialog {
+const logName = 'GoToDialog'
+export const goToDialogToken = token<IGoToDialog>(logName)
+export const goToDialogDependencies: Token<unknown>[] = [messageBusToken, translationServiceToken]
+export class GoToDialog implements IGoToDialog {
     readonly type = 'goto' as const
     constructor(
         private messageBus: IMessageBus,

--- a/packages/engine/builders/containerBuilders/actionsBuilder.ts
+++ b/packages/engine/builders/containerBuilders/actionsBuilder.ts
@@ -1,6 +1,6 @@
 import { ActionExecutor, actionExecutorDependencies, actionExecutorToken } from '@actions/actionExecutor'
 import { EndDialog, endDialogDependencies, endDialogToken } from '@actions/endDialog'
-import { GotoDialog, gotoDialogDependencies, gotoDialogToken } from '@actions/gotoDialog'
+import { GoToDialog, goToDialogDependencies, goToDialogToken } from '@actions/goToDialog'
 import { PostMessageAction, postMessageActionDependencies, postMessageActionToken } from '@actions/postMessageAction'
 import { ScriptAction, scriptActionDependencies, scriptActionToken } from '@actions/scriptAction'
 import { Container } from '@ioc/container'
@@ -18,9 +18,9 @@ export class ActionsBuilder {
             deps: endDialogDependencies
         })
         container.register({
-            token: gotoDialogToken,
-            useClass: GotoDialog,
-            deps: gotoDialogDependencies
+            token: goToDialogToken,
+            useClass: GoToDialog,
+            deps: goToDialogDependencies
         })
         container.register({
             token: postMessageActionToken,

--- a/packages/engine/main.tsx
+++ b/packages/engine/main.tsx
@@ -13,7 +13,7 @@ import { ContainerBuilder, IContainerBuilder } from '@builders/containerBuilder'
 import { ActionHandlerRegistrar, ConditionResolverRegistrar, InputsProviderRegistrar } from '@builders/containerBuilders/registrars'
 import { postMessageActionToken } from '@actions/postMessageAction'
 import { scriptActionToken } from '@actions/scriptAction'
-import { gotoDialogToken } from '@actions/gotoDialog'
+import { goToDialogToken } from '@actions/goToDialog'
 import { endDialogToken } from '@actions/endDialog'
 import { pageInputsToken } from '@inputs/pageInputs'
 import { dialogInputsToken } from '@inputs/dialogInputs'
@@ -30,7 +30,7 @@ const containerBuilder: IContainerBuilder = new ContainerBuilder(
   [
     (r => r.registerActionHandler('post-message', postMessageActionToken)) as ActionHandlerRegistrar,
     (r => r.registerActionHandler('script', scriptActionToken)) as ActionHandlerRegistrar,
-    (r => r.registerActionHandler('goto', gotoDialogToken)) as ActionHandlerRegistrar,
+    (r => r.registerActionHandler('goto', goToDialogToken)) as ActionHandlerRegistrar,
     (r => r.registerActionHandler('end-dialog', endDialogToken)) as ActionHandlerRegistrar,
   ],
   [


### PR DESCRIPTION
## Summary
- rename action files and symbols from gotoDialog to goToDialog
- update engine builder and main registration

## Testing
- `npm run build`
- `npm run build:editor`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68aad65a0d6083328f7aa5a542b17867