### PR TITLE
refactor: replace var with const in edit tree provider

### DIFF
--- a/packages/editor/providers/editTreeProvider.ts
+++ b/packages/editor/providers/editTreeProvider.ts
@@ -44,7 +44,7 @@ export class EditTreeProvider implements IEditTreeProvider {
     }
 
     private getItem(item: BaseItem): GameItemTreeNode {
-        var result = {
+        const result = {
             label: item.label,
             id: item.id,
             data: item,


### PR DESCRIPTION
## Summary
- use `const` instead of `var` in edit tree provider

## Testing
- `npm run build`
- `npm run build:editor`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68ab015f7cf8833286e027c1a722c6d6