### PR TITLE
Handle game load failures

### DIFF
--- a/packages/editor/managers/gameDataLoaderManager.ts
+++ b/packages/editor/managers/gameDataLoaderManager.ts
@@ -46,7 +46,13 @@ export class GameDataLoaderManager implements IGameDataLoaderManager {
 
     private async onInitialized(): Promise<void> {
         const path = `${this.dataUrl}/index.json`
-        const game = await loadJsonResource<Game>(path, gameSchema, this.logger)
+        let game: Game
+        try {
+            game = await loadJsonResource<Game>(path, gameSchema, this.logger)
+        } catch (error) {
+            this.logger.error(logName, 'Failed to load game definition from {0}: {1}', path, error)
+            return
+        }
         this.gameDataProvider.setGame(game)
         this.messageBus.postMessage({
             message: GAME_DEFINITION_UPDATED,


### PR DESCRIPTION
## Summary
- avoid crashing editor when initial game load fails
- log game load errors and skip update messages

## Testing
- `npm run build`
- `npm run build:editor`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68ab016fe10c8332a45b7ba16da4a65e