### PR TITLE
Specify cors version for editor package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5949,7 +5949,7 @@
             "version": "1.0.0",
             "dependencies": {
                 "@angelabc/shared": "1.0.0",
-                "cors": "^*",
+                "cors": "^2.8.5",
                 "express": "^5.1.0",
                 "react": "^18.3.1",
                 "react-dom": "^18.3.1",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "dependencies": {
     "express": "^5.1.0",
-    "cors": "^*",
+    "cors": "^2.8.5",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-icons": "^5.5.0",


### PR DESCRIPTION
## Summary
- pin `cors` dependency for `@angelabc/editor` to `^2.8.5`
- regenerate `package-lock.json` for the new cors resolution

## Testing
- `npm run build`
- `npm run build:editor`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68ab0186603083329b5684ad87e356bf