### PR TITLE
feat(editor): log startup errors

### DIFF
--- a/packages/editor/main.tsx
+++ b/packages/editor/main.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { App } from './app/App'
 import { ContainerBuilder, IContainerBuilder } from './builders/containerBuilder'
-import { ConsoleLogger } from '@utils/logger'
+import { ConsoleLogger, loggerToken } from '@utils/logger'
 import { IocProvider } from '@ioc/IocProvider'
 import { Container } from '@ioc/container'
 import { editorToken, IEditor } from './core/editor'
@@ -10,6 +10,7 @@ import './styling/reset.css'
 import './styling/variables.css'
 import './styling/editor.css'
 
+const logName = 'main'
 const containerBuilder: IContainerBuilder = new ContainerBuilder(
   () => new ConsoleLogger(),
   import.meta.env.VITE_DATA_URL ?? 'http://localhost:3000/data'
@@ -32,6 +33,7 @@ if (rootElement) {
     const editor = container.resolve<IEditor>(editorToken)
     await editor.start()
   } catch (err) {
-    console.error('Editor failed to start', err)
+    const logger = container.resolve(loggerToken)
+    logger.error(logName, 'Editor failed to start: {0}', err)
   }
 })()


### PR DESCRIPTION
## Summary
- resolve logger from container in editor main
- log editor startup failures through logger

## Testing
- `npm run build`
- `npm run build:editor`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68ab01910930833298eee3f30a7c8624