### PR TITLE
refactor(editor): simplify Content effect dependencies

### DIFF
--- a/packages/editor/app/Content.tsx
+++ b/packages/editor/app/Content.tsx
@@ -28,7 +28,7 @@ export const Content: React.FC = (): React.JSX.Element => {
                 setContentInfo(message.payload as SetEditorContentPayload)
             }
         )
-    }, [messageBus, setContentInfo])
+    }, [messageBus])
 
     if (contentInfo === null || contentInfo.type === null) return (<></>)
 


### PR DESCRIPTION
## Summary
- remove setContentInfo from Content effect dependencies since state setters are stable

## Testing
- `npm run build`
- `npm run build:editor`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68ab019f371c8332b3bfda103a6e00e1