### PR TITLE
docs: document editor architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ The server reads from `VITE_DATA_PATH` (defaults to `/data`) and exposes:
 
 `VITE_EDITOR_ORIGIN` may be set to configure the allowed CORS origin for the server. It defaults to `http://localhost:5174`.
 
+## Documentation
+- [Engine Overview](docs/engine.md)
+- [Editor Architecture](docs/editor.md)
+
 ## Testing and Build Commands
 Run the following commands before submitting changes:
 

--- a/docs/editor.md
+++ b/docs/editor.md
@@ -1,0 +1,15 @@
+# Editor Overview
+
+The `editor` directory contains the content authoring tool built with React. It is a standalone application that shares only low-level utilities with the game engine.
+
+## IoC Setup
+
+Dependencies are managed through the shared inversion of control container. [`ContainerBuilder`](../packages/editor/builders/containerBuilder.ts) composes the editor's services by registering utilities, static configuration like the data URL, and the editor-specific builders for core, managers, and providers. `main.tsx` builds the container, supplies it to React's `<IocProvider>`, and resolves the `editor` before calling `start()`.
+
+## Message Flow
+
+The editor relies on the shared [`MessageBus`](../packages/shared/utils/messageBus.ts) for decoupled communication. [`Editor.start()`](../packages/editor/core/editor.ts) posts the `INITIALIZED` message after running initializers. [`GameDataLoaderManager`](../packages/editor/managers/gameDataLoaderManager.ts) listens for this message, loads the game definition, and emits `GAME_DEFINITION_UPDATED`. Providers such as [`GameDataProvider`](../packages/editor/providers/gameDataProvider.ts) send `SET_EDITOR_CONTENT` messages when new content is ready for the UI.
+
+## Separation from the Engine
+
+The editor is intentionally isolated from the runtime engine. Aside from shared modules in `@utils`, `@ioc`, and `@loader/schema`, it avoids importing engine classes or components. This separation keeps the editor focused on authoring while the engine handles gameplay.


### PR DESCRIPTION
## Summary
- add editor architecture doc detailing IoC container, message flow, and isolation from the engine
- link engine and editor docs in README

## Testing
- `npm run build`
- `npm run build:editor`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab01abf73483328d8d84dd73e0ef2e