### PR TITLE
refactor(editor): use CSS variables

### DIFF
--- a/packages/editor/styling/editor.css
+++ b/packages/editor/styling/editor.css
@@ -2,7 +2,7 @@ body {
     overflow: hidden;
     width: 100vw;
     height: 100vh;
-    font-family: arial;
+    font-family: var(--font-family);
 }
 
 #root {
@@ -13,7 +13,7 @@ body {
 }
 
 aside.side-bar {
-    border-right: solid 1px black;
+    border-right: solid 1px var(--border-color);
     overflow: auto;
     line-height: 110%;
 
@@ -25,7 +25,7 @@ aside.side-bar {
         cursor: pointer;
         display: flex;
         align-items: center;
-        gap: 6px;
+        gap: var(--spacing-sm);
     }
 }
 
@@ -43,12 +43,12 @@ header.content-bar {
     position: sticky;
     top: 0;
     z-index: 10;
-    padding: 10px;
+    padding: var(--spacing-md);
     font-size: 125%;
     align-items: center;
     display: grid;
     grid-template-columns: 1fr 450px 170px;
-    background-color: #ddd;
+    background-color: var(--background-color);
 
     & button {
         width: 170px;
@@ -64,10 +64,10 @@ main.content {
 
     & .panel {
         font-size: 125%;
-        margin-top: 25px;
+        margin-top: var(--spacing-lg);
 
         & legend {
-            border-bottom: solid 1px #333;
+            border-bottom: solid 1px var(--border-color);
             margin-bottom: 20px;
         }
     }
@@ -77,19 +77,19 @@ main.content {
     }
 
     & .button-bar {
-        margin-top: 25px;
+        margin-top: var(--spacing-lg);
         font-size: 125%;
 
         & button {
             width: 170px;
-            margin-right: 10px;
+            margin-right: var(--spacing-md);
             border-radius: 5px;
             cursor: pointer;
         }
     }
 
     & .labeled-control {
-        margin-top: 10px;
+        margin-top: var(--spacing-md);
         display: grid;
         grid-template-columns: 150px 1fr;
 

--- a/packages/editor/styling/variables.css
+++ b/packages/editor/styling/variables.css
@@ -1,0 +1,10 @@
+:root {
+    --primary-color: #333;
+    --background-color: #ddd;
+    --font-family: Arial, sans-serif;
+    --border-color: var(--primary-color);
+    --spacing-sm: 6px;
+    --spacing-md: 10px;
+    --spacing-lg: 25px;
+}
+


### PR DESCRIPTION
## Summary
- define base color, font, and spacing variables for the editor
- replace hard-coded editor styles with CSS variables

## Testing
- `npm run build`
- `npm run build:editor`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68ac5bf8d14c83328fe3dcb185b32f4c