### PR TITLE
feat(editor): add collapsible sidebar

### DIFF
--- a/packages/editor/app/App.tsx
+++ b/packages/editor/app/App.tsx
@@ -1,12 +1,19 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { Tree } from './Tree'
 import { Content } from './Content'
 
 export const App: React.FC = () => {
+  const [collapsed, setCollapsed] = useState(false)
+
+  useEffect(() => {
+    const root = document.getElementById('root')
+    root?.style.setProperty('--sidebar-width', collapsed ? '0px' : '300px')
+  }, [collapsed])
+
   return (
     <>
-      <Tree />
-      <Content />
+      <Tree collapsed={collapsed} />
+      <Content onToggleSidebar={() => setCollapsed(prev => !prev)} />
     </>
   )
 }

--- a/packages/editor/app/Content.tsx
+++ b/packages/editor/app/Content.tsx
@@ -18,7 +18,11 @@ const contentPages: Record<BaseItemType, ComponentType<BaseContentProps>> = {
     'translations': BaseContent,
 }
 
-export const Content: React.FC = (): React.JSX.Element => {
+interface ContentProps {
+    onToggleSidebar: () => void
+}
+
+export const Content: React.FC<ContentProps> = ({ onToggleSidebar }): React.JSX.Element => {
     const [contentInfo, setContentInfo] = useState<SetEditorContentPayload | null>(null)
     const messageBus = useService<IMessageBus>(messageBusToken)
     useEffect(() => {
@@ -35,7 +39,7 @@ export const Content: React.FC = (): React.JSX.Element => {
     const MyContent = contentPages[contentInfo.type]
     return (
         <section className='main'>
-            <ContentBar />
+            <ContentBar onToggleSidebar={onToggleSidebar} />
             <main className='content'>
                 <MyContent id={contentInfo.id} label={contentInfo.label} />
             </main>

--- a/packages/editor/app/ContentBar.tsx
+++ b/packages/editor/app/ContentBar.tsx
@@ -5,8 +5,12 @@ import { ILogger, loggerToken } from '@utils/logger'
 import { IMessageBus, messageBusToken } from '@utils/messageBus'
 import { useEffect, useState } from 'react'
 
+interface ContentBarProps {
+    onToggleSidebar: () => void
+}
+
 const logName = 'ContentBar'
-export const ContentBar: React.FC = (): React.JSX.Element => {
+export const ContentBar: React.FC<ContentBarProps> = ({ onToggleSidebar }): React.JSX.Element => {
     const gameDataStoreProvider = useService<IGameDataStoreProvider>(gameDataStoreProviderToken)
     const logger = useService<ILogger>(loggerToken)
     const messageBus = useService<IMessageBus>(messageBusToken)
@@ -24,7 +28,7 @@ export const ContentBar: React.FC = (): React.JSX.Element => {
 
     return (
         <header className='content-bar'>
-            <span />
+            <button type='button' onClick={onToggleSidebar}>Toggle Sidebar</button>
             <span className='notify'>
             {isChanged ? 'There are pending changes waiting to be saved.' : ''}
             </span>

--- a/packages/editor/app/Tree.tsx
+++ b/packages/editor/app/Tree.tsx
@@ -3,9 +3,14 @@ import { editTreeProviderToken, GameItemTreeNode, IEditTreeProvider } from '@edi
 import { useService } from '@ioc/IocProvider'
 import { IMessageBus, messageBusToken } from '@utils/messageBus'
 import { useEffect, useState } from 'react'
+import classNames from 'classnames'
 import { TreeNode } from './TreeNode'
 
-export const Tree: React.FC = (): React.JSX.Element => {
+interface TreeProps {
+    collapsed: boolean
+}
+
+export const Tree: React.FC<TreeProps> = ({ collapsed }): React.JSX.Element => {
     const messageBus = useService<IMessageBus>(messageBusToken)
     const editTreeProvider = useService<IEditTreeProvider>(editTreeProviderToken)
     const [root, setRoot] = useState<GameItemTreeNode | null>(null)
@@ -18,9 +23,9 @@ export const Tree: React.FC = (): React.JSX.Element => {
     }, [messageBus, editTreeProvider])
 
     return (
-        <aside className='side-bar'>
+        <aside className={classNames('side-bar', { collapsed })}>
             {root !== null && root.children.length > 0 && (
-                <TreeNode node={root} key={root.id} initialCollapse={false}  />
+                <TreeNode node={root} key={root.id} initialCollapse={false} />
             )}
         </aside>
     )

--- a/packages/editor/styling/editor.css
+++ b/packages/editor/styling/editor.css
@@ -7,7 +7,7 @@ body {
 
 #root {
     display: grid;
-    grid-template-columns: 300px 1fr;
+    grid-template-columns: var(--sidebar-width, 300px) 1fr;
     min-height: 100%;
     width: 100%;
 }
@@ -27,6 +27,10 @@ aside.side-bar {
         align-items: center;
         gap: var(--spacing-sm);
     }
+}
+
+aside.side-bar.collapsed {
+    display: none;
 }
 
 


### PR DESCRIPTION
## Summary
- allow responsive sidebar width using CSS variables
- add stateful toggle to collapse or expand the editor sidebar
- expose sidebar toggle from ContentBar
- use classnames helper for sidebar collapse styling

## Testing
- `npm run lint`
- `npm run build`
- `npm run build:editor`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68ac6acdccb0833293943fdddc39e642