### PR TITLE
Refactor editor sidebar to use CSS variables

### DIFF
--- a/packages/editor/app/App.tsx
+++ b/packages/editor/app/App.tsx
@@ -8,7 +8,7 @@ export const App: React.FC = () => {
 
   useEffect(() => {
     const root = document.getElementById('root')
-    root?.style.setProperty('--sidebar-width', collapsed ? '30px' : '300px')
+    root?.classList.toggle('collapsed', collapsed)
   }, [collapsed])
 
   return (

--- a/packages/editor/styling/editor.css
+++ b/packages/editor/styling/editor.css
@@ -38,10 +38,15 @@ select:focus-visible {
     width: 100%;
 }
 
+#root.collapsed {
+    grid-template-columns: var(--sidebar-collapse-width) 1fr;
+}
+
 aside.side-bar {
     border-right: solid 1px var(--border-color);
     overflow: auto;
     line-height: 110%;
+    width: var(--sidebar-width);
 
     & .children {
         padding-left: 22px;
@@ -57,7 +62,8 @@ aside.side-bar {
     & .toggle-collapse {
         position: fixed;
         bottom: 2px;
-        left: calc(var(--sidebar-width) - 25px);
+        left: var(--sidebar-width);
+        transform: translateX(-100%);
     }
 }
 
@@ -66,7 +72,7 @@ aside.side-bar.collapsed {
     overflow: hidden;
 
     & .toggle-collapse {
-        left: calc(var(--sidebar-collapse-width) - 25px);
+        left: var(--sidebar-collapse-width);
     }
 }
 

--- a/packages/editor/styling/variables.css
+++ b/packages/editor/styling/variables.css
@@ -7,5 +7,6 @@
     --spacing-md: 10px;
     --spacing-lg: 25px;
     --sidebar-width: 300px;
+    --sidebar-collapse-width: 30px;
 }
 


### PR DESCRIPTION
## Summary
- define sidebar width and collapsed width variables
- toggle root `collapsed` class instead of inline styles
- align sidebar and toggle button layout with CSS variables

## Testing
- `npm run build`
- `npm run build:editor`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68ac8c2a48888332a2957b82c8f1d185