### PR TITLE
Implement editor save functionality

### DIFF
--- a/packages/editor/app/ContentBar.tsx
+++ b/packages/editor/app/ContentBar.tsx
@@ -11,8 +11,24 @@ export const ContentBar: React.FC = (): React.JSX.Element => {
     const logger = useService<ILogger>(loggerToken)
     const messageBus = useService<IMessageBus>(messageBusToken)
     const [isChanged, setIsChanged] = useState<boolean>(gameDataStoreProvider.IsChanged)
-    const onSaveClicked = (): void => {
-        logger.warn(logName, 'Not implemented yet')
+    const onSaveClicked = async (): Promise<void> => {
+        const items = gameDataStoreProvider.getChangedItems()
+        try {
+            await Promise.all(
+                items.map(item =>
+                    fetch(`/data/${item.path}`, {
+                        method: 'PUT',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify(item.data)
+                    })
+                )
+            )
+            gameDataStoreProvider.markSaved()
+            setIsChanged(false)
+            messageBus.postMessage({ message: GAME_DATA_STORE_CHANGED })
+        } catch (err) {
+            logger.warn(logName, 'Error saving changes: {0}', err)
+        }
     }
 
     useEffect(() => {
@@ -31,7 +47,7 @@ export const ContentBar: React.FC = (): React.JSX.Element => {
             <button
                 type='button'
                 disabled={!isChanged}
-                onClick={() => onSaveClicked}
+                onClick={onSaveClicked}
             >
                 Save
             </button>

--- a/packages/editor/providers/gameDataStoreProvider.ts
+++ b/packages/editor/providers/gameDataStoreProvider.ts
@@ -10,6 +10,8 @@ export interface IGameDataStoreProvider {
     retrieveItem<T>(id: number): StoreItem<T>
     hasData(id: number): boolean
     get IsChanged(): boolean
+    getChangedItems(): Array<{ path: string; data: unknown }>
+    markSaved(): void
 }
 
 export const rootPath = 'index.json'
@@ -87,6 +89,23 @@ export class GameDataStoreProvider implements IGameDataStoreProvider {
         }
         const error = this.logger.error(logName, 'Game item with id {0} not found in store', id)
         throw new Error(error)
+    }
+
+    public getChangedItems(): Array<{ path: string; data: unknown }> {
+        const changed: Array<{ path: string; data: unknown }> = []
+        this.items.forEach(item => {
+            if (JSON.stringify(item.Original) !== JSON.stringify(item.current)) {
+                changed.push({ path: item.path, data: item.current })
+            }
+        })
+        return changed
+    }
+
+    public markSaved(): void {
+        this.items.forEach(item => {
+            item.Original = item.current
+        })
+        this.isChanged = false
     }
 
 }


### PR DESCRIPTION
## Summary
- Hook ContentBar save button to send modified game data via PUT requests and notify listeners when complete
- Extend GameDataStoreProvider with change tracking and save-reset support

## Testing
- `npm run build`
- `npm run build:editor`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68ae0dc9ea4483329954e6933f9b6a0a