### PR TITLE
Use fieldset for editor panel layout

### DIFF
--- a/packages/editor/app/controls/Panel.tsx
+++ b/packages/editor/app/controls/Panel.tsx
@@ -7,9 +7,9 @@ export interface PanelProps {
 
 export const Panel: React.FC<PanelProps> = ({title, children}): React.JSX.Element => {
     return (
-        <div className='panel'>
+        <fieldset className='panel'>
             <legend>{title}</legend>
             {children}
-        </div>    
+        </fieldset>
         )
 }

--- a/packages/editor/styling/editor.css
+++ b/packages/editor/styling/editor.css
@@ -115,6 +115,8 @@ main.content {
     & .panel {
         font-size: 125%;
         margin-top: var(--spacing-lg);
+        border: none;
+        padding: 0;
 
         & legend {
             border-bottom: solid 1px var(--border-color);


### PR DESCRIPTION
## Summary
- Wrap editor panel content in a `<fieldset>` with `<legend>` header
- Reset panel styling to remove default fieldset border and padding

## Testing
- `npm run build`
- `npm run build:editor`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68ae1299a35c8332a4b5e4a7b7c4f1de