### PR TITLE
feat(editor): add language management UI

### DIFF
--- a/packages/editor/app/content/LanguagesContent.tsx
+++ b/packages/editor/app/content/LanguagesContent.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { useService } from '@ioc/IocProvider'
 import { BaseContentProps } from './BaseContent'
 import { gameDataStoreProviderToken, IGameDataStoreProvider } from '@editor/providers/gameDataStoreProvider'
@@ -6,12 +7,36 @@ import { Panel } from '../controls/Panel'
 
 export const LanguagesContent: React.FC<BaseContentProps> = ({ id, label }): React.JSX.Element => {
     const gameDataStoreProvider = useService<IGameDataStoreProvider>(gameDataStoreProviderToken)
-    const languages = gameDataStoreProvider.retrieve<Languages>(id)
+    const [languages, setLanguages] = useState<Languages>(() => [...gameDataStoreProvider.retrieve<Languages>(id)])
+    const [newLanguage, setNewLanguage] = useState('')
+
+    const addLanguage = (): void => {
+        const trimmed = newLanguage.trim()
+        if (trimmed === '' || languages.includes(trimmed)) {
+            return
+        }
+        const updated = [...languages, trimmed]
+        setLanguages(updated)
+        setNewLanguage('')
+        gameDataStoreProvider.update(id, updated)
+    }
+
+    const removeLanguage = (lan: string): void => {
+        const updated = languages.filter(l => l !== lan)
+        setLanguages(updated)
+        gameDataStoreProvider.update(id, updated)
+    }
+
     return (
         <Panel title={label}>
             {languages.map(lan => (
-                <div>{lan}</div>
+                <div key={lan}>
+                    {lan}
+                    <button aria-label={`remove-${lan}`} onClick={() => removeLanguage(lan)}>Remove</button>
+                </div>
             ))}
+            <input aria-label='new-language' value={newLanguage} onChange={e => setNewLanguage(e.target.value)} />
+            <button onClick={addLanguage}>Add language</button>
         </Panel>
     )
 }

--- a/tests/editor/LanguagesContent.test.tsx
+++ b/tests/editor/LanguagesContent.test.tsx
@@ -1,0 +1,33 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { services } from '../app/testUtils'
+import { LanguagesContent } from '../../packages/editor/app/content/LanguagesContent'
+import { gameDataStoreProviderToken, type IGameDataStoreProvider } from '../../packages/editor/providers/gameDataStoreProvider'
+
+describe('LanguagesContent', () => {
+  beforeEach(() => services.clear())
+
+  it('adds and removes languages and updates store', () => {
+    const provider = {
+      retrieve: vi.fn(() => ['en']),
+      update: vi.fn()
+    } as unknown as IGameDataStoreProvider
+    services.set(gameDataStoreProviderToken, provider)
+
+    render(<LanguagesContent id={1} label='Languages' />)
+
+    // Add a language
+    fireEvent.change(screen.getByLabelText('new-language'), { target: { value: 'de' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Add language' }))
+
+    expect(provider.update).toHaveBeenLastCalledWith(1, ['en', 'de'])
+    expect(screen.getByText('de')).toBeDefined()
+
+    // Remove existing language
+    fireEvent.click(screen.getByLabelText('remove-en'))
+
+    expect(provider.update).toHaveBeenLastCalledWith(1, ['de'])
+    expect(screen.queryByText('en')).toBeNull()
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
       '@builders': fileURLToPath(new URL('./packages/engine/builders', import.meta.url)),
       '@conditions': fileURLToPath(new URL('./packages/engine/conditions', import.meta.url)),
       '@core': fileURLToPath(new URL('./packages/engine/core', import.meta.url)),
+      '@editor': fileURLToPath(new URL('./packages/editor', import.meta.url)),
       '@ioc': fileURLToPath(new URL('./packages/shared/ioc', import.meta.url)),
       '@inputs': fileURLToPath(new URL('./packages/engine/inputs', import.meta.url)),
       '@loader/schema': fileURLToPath(new URL('./packages/shared/loader/schema', import.meta.url)),


### PR DESCRIPTION
## Summary
- allow editor to add and remove languages while updating store
- support editor alias in Vite config
- test language add/remove functionality

## Testing
- `npm run build`
- `npm run build:editor`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68ae12a9d9e883329e98af6adfb47328