### PR TITLE
Add editor provider unit tests

### DIFF
--- a/tests/editor/editTreeProvider.test.ts
+++ b/tests/editor/editTreeProvider.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi } from 'vitest'
+import { EditTreeProvider } from '../../packages/editor/providers/editTreeProvider'
+import type { ILogger } from '@utils/logger'
+import type { IGameDataProvider } from '../../packages/editor/providers/gameDataProvider'
+import type { RootItem, BaseItem } from '../../packages/editor/types/gameItems'
+import type { Game } from '../../packages/engine/loader/data/game'
+
+const logger: ILogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn((c, m) => `[${c}] ${m}`)
+}
+
+const createGame = (): Game => ({
+  title: 'root',
+  description: '',
+  version: '1.0',
+  initialData: { language: 'en', startPage: 'start' },
+  languages: {},
+  pages: {},
+  maps: {},
+  tiles: {},
+  dialogs: {},
+  actions: [],
+  virtualKeys: [],
+  virtualInputs: [],
+  cssFiles: []
+})
+
+const createRoot = (): RootItem => ({
+  type: 'root',
+  id: 1,
+  label: 'Root',
+  game: createGame(),
+  children: [
+    {
+      type: 'pages',
+      id: 2,
+      label: 'Pages',
+      children: [
+        {
+          type: 'page',
+          id: 3,
+          label: 'First',
+          key: 'first',
+          path: 'first.json',
+          children: []
+        } as BaseItem
+      ]
+    } as BaseItem
+  ]
+})
+
+describe('editor EditTreeProvider', () => {
+  it('builds tree from game data', () => {
+    const gameDataProvider: IGameDataProvider = {
+      setGame: vi.fn(),
+      get Root () { return createRoot() }
+    }
+    const provider = new EditTreeProvider(logger, gameDataProvider)
+
+    const root = provider.Root
+
+    expect(root.label).toBe('Root')
+    expect(root.children[0].label).toBe('Pages')
+    expect(root.children[0].children[0].label).toBe('First')
+    expect(root.children[0].children[0].data?.id).toBe(3)
+  })
+
+  it('returns placeholder when no data is available', () => {
+    const gameDataProvider: IGameDataProvider = {
+      setGame: vi.fn(),
+      get Root () { return null as unknown as RootItem }
+    }
+    const provider = new EditTreeProvider(logger, gameDataProvider)
+
+    expect(provider.Root).toEqual({
+      label: 'No data',
+      data: null,
+      id: 0,
+      children: []
+    })
+  })
+})
+

--- a/tests/editor/gameDataProvider.test.ts
+++ b/tests/editor/gameDataProvider.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from 'vitest'
+import { GameDataProvider } from '../../packages/editor/providers/gameDataProvider'
+import { rootPath, type IGameDataStoreProvider } from '../../packages/editor/providers/gameDataStoreProvider'
+import type { Game } from '../../packages/engine/loader/data/game'
+import type { ILogger } from '@utils/logger'
+import type { IMessageBus } from '@utils/messageBus'
+import { SET_EDITOR_CONTENT } from '../../packages/editor/messages/editor'
+
+describe('editor GameDataProvider', () => {
+  const createDeps = () => {
+    const logger: ILogger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn((c, m, ...a) => `[${c}] ${m.replace('{0}', String(a[0]))}`)
+    }
+    const messageBus: IMessageBus = {
+      postMessage: vi.fn(),
+      registerMessageListener: vi.fn(),
+      registerNotificationMessage: vi.fn(),
+      unregisterNotificationMessage: vi.fn(),
+      disableEmptyQueueAfterPost: vi.fn(),
+      enableEmptyQueueAfterPost: vi.fn(),
+      shutDown: vi.fn()
+    }
+    const gameDataStoreProvider: IGameDataStoreProvider = {
+      store: vi.fn(),
+      update: vi.fn(),
+      retrieve: vi.fn(),
+      retrieveItem: vi.fn(),
+      hasData: vi.fn(),
+      get IsChanged () { return false },
+      getChangedItems: vi.fn(),
+      markSaved: vi.fn()
+    }
+    return { logger, messageBus, gameDataStoreProvider }
+  }
+
+  const createGame = (): Game => ({
+    title: 'Test Game',
+    description: '',
+    version: '1.0',
+    initialData: { language: 'en', startPage: 'start' },
+    languages: {
+      zLang: ['z2.json', 'z1.json'],
+      aLang: ['b.json', 'a.json']
+    },
+    pages: {
+      bPage: 'b.json',
+      aPage: 'a.json'
+    },
+    maps: {},
+    tiles: {},
+    dialogs: {},
+    actions: [],
+    virtualKeys: [],
+    virtualInputs: [],
+    cssFiles: []
+  })
+
+  it('creates tree, stores root and dispatches message', () => {
+    const { logger, messageBus, gameDataStoreProvider } = createDeps()
+    const provider = new GameDataProvider(logger, messageBus, gameDataStoreProvider)
+    const game = createGame()
+
+    provider.setGame(game)
+    const root = provider.Root
+
+    expect(root.label).toBe('Test Game')
+    expect(root.children.map(c => c.label)).toEqual(['Languages', 'Pages'])
+
+    const pagesItem = root.children.find(c => c.type === 'pages')!
+    expect(pagesItem.children.map(c => c.label)).toEqual(['aPage', 'bPage'])
+
+    const languagesItem = root.children.find(c => c.type === 'languages')!
+    expect(languagesItem.children.map(c => c.label)).toEqual(['aLang', 'zLang'])
+    const aLang = languagesItem.children[0]
+    expect(aLang.children.map(c => c.label)).toEqual(['a.json', 'b.json'])
+
+    expect(gameDataStoreProvider.store).toHaveBeenCalledWith(root.id, game, rootPath)
+    expect(messageBus.postMessage).toHaveBeenCalledWith({
+      message: SET_EDITOR_CONTENT,
+      payload: {
+        id: root.id,
+        label: root.label,
+        type: root.type
+      }
+    })
+  })
+})
+

--- a/tests/editor/gameDataStoreProvider.test.ts
+++ b/tests/editor/gameDataStoreProvider.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from 'vitest'
+import { GameDataStoreProvider } from '../../packages/editor/providers/gameDataStoreProvider'
+import { GAME_DATA_STORE_CHANGED } from '../../packages/editor/messages/editor'
+import type { ILogger } from '@utils/logger'
+import type { IMessageBus } from '@utils/messageBus'
+
+const createDeps = () => {
+  const logger: ILogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn((c, m, ...a) => `[${c}] ${m.replace('{0}', String(a[0]))}`)
+  }
+  const messageBus: IMessageBus = {
+    postMessage: vi.fn(),
+    registerMessageListener: vi.fn(),
+    registerNotificationMessage: vi.fn(),
+    unregisterNotificationMessage: vi.fn(),
+    disableEmptyQueueAfterPost: vi.fn(),
+    enableEmptyQueueAfterPost: vi.fn(),
+    shutDown: vi.fn()
+  }
+  return { logger, messageBus }
+}
+
+describe('editor GameDataStoreProvider', () => {
+  it('stores, updates and retrieves data while dispatching messages', () => {
+    const { logger, messageBus } = createDeps()
+    const provider = new GameDataStoreProvider(logger, messageBus)
+
+    provider.store(1, { value: 1 }, 'path1')
+
+    expect(messageBus.postMessage).toHaveBeenCalledWith({
+      message: GAME_DATA_STORE_CHANGED,
+      payload: 1
+    })
+    expect(provider.hasData(1)).toBe(true)
+    expect(provider.retrieve(1)).toEqual({ value: 1 })
+
+    provider.update(1, { value: 2 })
+    expect(messageBus.postMessage).toHaveBeenNthCalledWith(2, {
+      message: GAME_DATA_STORE_CHANGED,
+      payload: 1
+    })
+    expect(provider.retrieve(1)).toEqual({ value: 2 })
+    expect(provider.IsChanged).toBe(true)
+    expect(provider.getChangedItems()).toEqual([
+      { path: 'path1', data: { value: 2 } }
+    ])
+
+    provider.markSaved()
+    expect(provider.IsChanged).toBe(false)
+    expect(provider.getChangedItems()).toEqual([])
+  })
+
+  it('throws when retrieving unknown id', () => {
+    const { logger, messageBus } = createDeps()
+    const provider = new GameDataStoreProvider(logger, messageBus)
+
+    expect(() => provider.retrieve(99)).toThrow('[GameDataStoreProvider] Game item with id 99 not found in store')
+    expect(logger.error).toHaveBeenCalledWith('GameDataStoreProvider', 'Game item with id {0} not found in store', 99)
+  })
+})
+

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -13,7 +13,8 @@
     "paths": {
       "@utils/*": ["./packages/shared/utils/*"],
       "@ioc/*": ["./packages/shared/ioc/*"],
-      "@loader/schema/*": ["./packages/shared/loader/schema/*"]
+      "@loader/schema/*": ["./packages/shared/loader/schema/*"],
+      "@editor/*": ["./packages/editor/*"]
     }
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -34,6 +34,7 @@ export default defineConfig({
       '@loader/schema': fileURLToPath(new URL('./packages/shared/loader/schema', import.meta.url)),
       '@loader': fileURLToPath(new URL('./packages/engine/loader', import.meta.url)),
       '@managers': fileURLToPath(new URL('./packages/engine/managers', import.meta.url)),
+      '@editor': fileURLToPath(new URL('./packages/editor', import.meta.url)),
       '@messages': fileURLToPath(new URL('./packages/engine/messages', import.meta.url)),
       '@providers': fileURLToPath(new URL('./packages/engine/providers', import.meta.url)),
       '@registries': fileURLToPath(new URL('./packages/engine/registries', import.meta.url)),


### PR DESCRIPTION
## Summary
- add unit tests for editor game data providers and tree builder
- configure @editor path alias for test resolution

## Testing
- `npm run build`
- `npm run build:editor`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae128c8fac8332be56d81bdac6d7d0