### PR TITLE
feat(editor): add game json saver

### DIFF
--- a/packages/editor/savers/gameJsonSaver.ts
+++ b/packages/editor/savers/gameJsonSaver.ts
@@ -1,0 +1,27 @@
+import { dataUrlToken } from '@editor/managers/gameDataLoaderManager'
+import { Token, token } from '@ioc/token'
+import { saveJsonResource } from '@utils/saveJsonResource'
+import { ILogger, loggerToken } from '@utils/logger'
+import { ZodType } from 'zod'
+
+export interface IGameJsonSaver {
+    saveJson<T>(path: string, data: T, schema: ZodType<T>): Promise<void>
+}
+
+const logName = 'GameJsonSaver'
+export const gameJsonSaverToken = token<IGameJsonSaver>(logName)
+export const gameJsonSaverDependencies: Token<unknown>[] = [
+    loggerToken,
+    dataUrlToken
+]
+export class GameJsonSaver implements IGameJsonSaver {
+    constructor(
+        private logger: ILogger,
+        private dataUrl: string
+    ) {}
+
+    public async saveJson<T>(path: string, data: T, schema: ZodType<T>): Promise<void> {
+        await saveJsonResource(`${this.dataUrl}/${path}`, data, schema, this.logger)
+    }
+}
+

--- a/packages/shared/utils/saveJsonResource.ts
+++ b/packages/shared/utils/saveJsonResource.ts
@@ -1,0 +1,48 @@
+/**
+ * Saves JSON resources validated by a provided Zod schema.
+ * Emits debug logs and halts execution via {@link fatalError} on failure.
+ */
+import { ZodType } from 'zod'
+import { fatalError } from './logMessage'
+import type { ILogger } from './logger'
+
+const logName = 'saveJsonResource'
+
+/**
+ * Validate and send a JSON document to a URL using HTTP PUT.
+ *
+ * @param url The destination for the JSON resource.
+ * @param data The data to serialize and send.
+ * @param schema A Zod schema describing the expected shape of the data.
+ * @throws {Error} If validation fails or the network request errors. Errors are
+ * reported via {@link fatalError} which throws.
+ */
+export async function saveJsonResource<T>(url: string, data: unknown, schema: ZodType<T>, logger: ILogger): Promise<void> {
+    logger.debug(logName, 'Saving JSON resource to {0}', url)
+
+    const parseResult = schema.safeParse(data)
+    if (!parseResult.success) {
+        fatalError(logName, 'Schema validation failed for resource {0} with error {1}', url, parseResult.error.message)
+    }
+
+    let response: Response
+    try {
+        response = await fetch(url, {
+            method: 'PUT',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(parseResult.data)
+        })
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        fatalError(logName, 'Failed to save {0} with message {1}', url, message)
+    }
+
+    if (!response.ok) {
+        fatalError(logName, 'Failed to save resource {0} with response {1}', url, response)
+    }
+
+    logger.debug(logName, 'Successfully saved resource to {0}', url)
+}
+

--- a/tests/utils/saveJsonResource.test.ts
+++ b/tests/utils/saveJsonResource.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { z } from 'zod'
+import { saveJsonResource } from '@utils/saveJsonResource'
+import * as log from '@utils/logMessage'
+import type { ILogger } from '@utils/logger'
+
+const originalFetch = globalThis.fetch
+
+afterEach(() => {
+    vi.restoreAllMocks()
+    globalThis.fetch = originalFetch
+})
+
+describe('saveJsonResource', () => {
+    it('saves valid JSON successfully', async () => {
+        const data = { id: 'abc' }
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true } as unknown as Response))
+        const schema = z.object({ id: z.string() })
+        const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+        await expect(saveJsonResource('/url', data, schema, logger)).resolves.toBeUndefined()
+        expect(fetch).toHaveBeenCalledWith('/url', {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(data)
+        })
+    })
+
+    it('calls fatalError on network error', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network')))
+        const schema = z.object({ id: z.string() })
+        const fatalSpy = vi.spyOn(log, 'fatalError').mockImplementation(() => { throw new Error('fatal') })
+        const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+        await expect(saveJsonResource('/url', { id: 'abc' }, schema, logger)).rejects.toThrow('fatal')
+        expect(fatalSpy).toHaveBeenCalled()
+    })
+
+    it('calls fatalError on non-ok response', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false } as unknown as Response))
+        const schema = z.object({ id: z.string() })
+        const fatalSpy = vi.spyOn(log, 'fatalError').mockImplementation(() => { throw new Error('fatal') })
+        const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+        await expect(saveJsonResource('/url', { id: 'abc' }, schema, logger)).rejects.toThrow('fatal')
+        expect(fatalSpy).toHaveBeenCalled()
+    })
+
+    it('calls fatalError on schema validation failure', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true } as unknown as Response))
+        const schema = z.object({ id: z.string() })
+        const fatalSpy = vi.spyOn(log, 'fatalError').mockImplementation(() => { throw new Error('fatal') })
+        const logger: ILogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+        await expect(saveJsonResource('/url', { id: 123 }, schema, logger)).rejects.toThrow('fatal')
+        expect(fatalSpy).toHaveBeenCalled()
+        expect(fetch).not.toHaveBeenCalled()
+    })
+})
+

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,7 +35,6 @@ export default defineConfig({
       '@loader/schema': fileURLToPath(new URL('./packages/shared/loader/schema', import.meta.url)),
       '@loader': fileURLToPath(new URL('./packages/engine/loader', import.meta.url)),
       '@managers': fileURLToPath(new URL('./packages/engine/managers', import.meta.url)),
-      '@editor': fileURLToPath(new URL('./packages/editor', import.meta.url)),
       '@messages': fileURLToPath(new URL('./packages/engine/messages', import.meta.url)),
       '@providers': fileURLToPath(new URL('./packages/engine/providers', import.meta.url)),
       '@registries': fileURLToPath(new URL('./packages/engine/registries', import.meta.url)),


### PR DESCRIPTION
## Summary
- support saving validated JSON resources
- add GameJsonSaver for editor modules
- fix Vite config alias for editor imports

## Testing
- `npm run build`
- `npm run build:editor`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68b0a2bf9aec83329daaf60973b40f03