### PR TITLE
Validate editor content payload before loading

### DIFF
--- a/packages/editor/managers/gameDataLoaderManager.ts
+++ b/packages/editor/managers/gameDataLoaderManager.ts
@@ -9,6 +9,7 @@ import { gameDataStoreProviderToken, IGameDataStoreProvider, rootPath } from '@e
 import { SetEditorContentPayload } from '@editor/messages/types'
 import { Languages } from '@editor/types/storeItems'
 import { gameJsonLoaderToken, IGameJsonLoader } from '@editor/loaders/gameJsonLoader'
+import { BaseItemType } from '@editor/types/gameItems'
 
 export interface IGameDataLoaderManager {
     initialize(): void
@@ -24,6 +25,26 @@ export const gameDataLoaderManagerDependencies: Token<unknown>[] = [
     gameDataStoreProviderToken,
     gameJsonLoaderToken
 ]
+
+const validBaseItemTypes: BaseItemType[] = [
+    'root',
+    'pages',
+    'page',
+    'languages',
+    'language',
+    'translations'
+]
+
+function isSetEditorContentPayload(payload: unknown): payload is SetEditorContentPayload {
+    if (typeof payload !== 'object' || payload === null) {
+        return false
+    }
+    const { id, label, type } = payload as Record<string, unknown>
+    return typeof id === 'number' &&
+        typeof label === 'string' &&
+        (type === null || (typeof type === 'string' && validBaseItemTypes.includes(type as BaseItemType)))
+}
+
 export class GameDataLoaderManager implements IGameDataLoaderManager {
     private cleanupFns: CleanUp[] = []
     constructor(
@@ -49,7 +70,13 @@ export class GameDataLoaderManager implements IGameDataLoaderManager {
             ),
             this.messageBus.registerMessageListener(
                 SET_EDITOR_CONTENT,
-                async message => await this.loadContent(message.payload as SetEditorContentPayload)
+                async message => {
+                    if (!isSetEditorContentPayload(message.payload)) {
+                        this.logger.error(logName, 'Invalid payload for {0}', SET_EDITOR_CONTENT)
+                        return
+                    }
+                    await this.loadContent(message.payload)
+                }
             )
         ]
     }
@@ -66,10 +93,9 @@ export class GameDataLoaderManager implements IGameDataLoaderManager {
                     this.gameDataStoreProvider.store(setEditorContent.id, languages, '')
                     break
                 }
-            default: {
-                const error = this.logger.error(logName, 'No loader for type {0}', setEditorContent.type)
-                throw new Error(error)
-            }
+            default:
+                this.logger.error(logName, 'No loader for type {0}', setEditorContent.type)
+                return
         }
     }
 

--- a/tests/editor/editTreeProvider.test.ts
+++ b/tests/editor/editTreeProvider.test.ts
@@ -56,7 +56,7 @@ describe('editor EditTreeProvider', () => {
   it('builds tree from game data', () => {
     const gameDataProvider: IGameDataProvider = {
       setGame: vi.fn(),
-      get Root () { return createRoot() }
+      get root () { return createRoot() }
     }
     const provider = new EditTreeProvider(logger, gameDataProvider)
 
@@ -71,7 +71,7 @@ describe('editor EditTreeProvider', () => {
   it('returns placeholder when no data is available', () => {
     const gameDataProvider: IGameDataProvider = {
       setGame: vi.fn(),
-      get Root () { return null as unknown as RootItem }
+      get root () { return null as unknown as RootItem }
     }
     const provider = new EditTreeProvider(logger, gameDataProvider)
 

--- a/tests/editor/gameDataProvider.test.ts
+++ b/tests/editor/gameDataProvider.test.ts
@@ -64,7 +64,7 @@ describe('editor GameDataProvider', () => {
     const game = createGame()
 
     provider.setGame(game)
-    const root = provider.Root
+    const root = provider.root
 
     expect(root.label).toBe('Test Game')
     expect(root.children.map(c => c.label)).toEqual(['Languages', 'Pages'])


### PR DESCRIPTION
## Summary
- add runtime type guard for SetEditorContentPayload in GameDataLoaderManager
- log and return on invalid payload or missing loader instead of throwing
- adjust editor tests to use the correct `root` property

## Testing
- `npm run build`
- `npm run build:editor`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68b2d49575c88332be8f2920a88de35e