### PR TITLE
Use deep cloning for game data store items

### DIFF
--- a/packages/editor/providers/gameDataStoreProvider.ts
+++ b/packages/editor/providers/gameDataStoreProvider.ts
@@ -46,8 +46,8 @@ export class GameDataStoreProvider implements IGameDataStoreProvider {
         }
         this.items.set(id, {
             path: path,
-            Original: { ...data },
-            current: { ...data }
+            Original: structuredClone(data),
+            current: structuredClone(data)
         })
         this.messageBus.postMessage({
             message: GAME_DATA_STORE_CHANGED,
@@ -103,7 +103,7 @@ export class GameDataStoreProvider implements IGameDataStoreProvider {
 
     public markSaved(): void {
         this.items.forEach(item => {
-            item.Original = item.current
+            item.Original = structuredClone(item.current)
         })
         this.isChanged = false
     }

--- a/tests/editor/editTreeProvider.test.ts
+++ b/tests/editor/editTreeProvider.test.ts
@@ -56,7 +56,7 @@ describe('editor EditTreeProvider', () => {
   it('builds tree from game data', () => {
     const gameDataProvider: IGameDataProvider = {
       setGame: vi.fn(),
-      get Root () { return createRoot() }
+      get root () { return createRoot() }
     }
     const provider = new EditTreeProvider(logger, gameDataProvider)
 
@@ -71,7 +71,7 @@ describe('editor EditTreeProvider', () => {
   it('returns placeholder when no data is available', () => {
     const gameDataProvider: IGameDataProvider = {
       setGame: vi.fn(),
-      get Root () { return null as unknown as RootItem }
+      get root () { return null as unknown as RootItem }
     }
     const provider = new EditTreeProvider(logger, gameDataProvider)
 

--- a/tests/editor/gameDataProvider.test.ts
+++ b/tests/editor/gameDataProvider.test.ts
@@ -64,7 +64,7 @@ describe('editor GameDataProvider', () => {
     const game = createGame()
 
     provider.setGame(game)
-    const root = provider.Root
+    const root = provider.root
 
     expect(root.label).toBe('Test Game')
     expect(root.children.map(c => c.label)).toEqual(['Languages', 'Pages'])


### PR DESCRIPTION
## Summary
- clone stored game data deeply to keep original and current state isolated
- deep clone current data when marking saved
- align editor tests with `root` accessor

## Testing
- `npm run build`
- `npm run build:editor`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68b2d4836298833299d9af0ce074a457