### PR TITLE
chore: remove unused shared dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5976,7 +5976,6 @@
             "name": "@angelabc/editor",
             "version": "1.0.0",
             "dependencies": {
-                "@angelabc/shared": "1.0.0",
                 "@hookform/resolvers": "^3.9.0",
                 "cors": "^2.8.5",
                 "express": "^5.1.0",
@@ -5990,7 +5989,6 @@
             "name": "@angelabc/engine",
             "version": "1.0.0",
             "dependencies": {
-                "@angelabc/shared": "1.0.0",
                 "react": "^18.3.1",
                 "react-dom": "^18.3.1",
                 "zod": "^4.1.1"

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -10,7 +10,6 @@
     "react-dom": "^18.3.1",
     "react-icons": "^5.5.0",
     "react-hook-form": "^7.53.0",
-    "@hookform/resolvers": "^3.9.0",
-    "@angelabc/shared": "1.0.0"
+    "@hookform/resolvers": "^3.9.0"
   }
 }

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -6,7 +6,6 @@
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "zod": "^4.1.1",
-    "@angelabc/shared": "1.0.0"
+    "zod": "^4.1.1"
   }
 }


### PR DESCRIPTION
## Summary
- remove `@angelabc/shared` from engine and editor packages
- uninstall `@angelabc/shared`

## Testing
- `npm run build`
- `npm run build:editor`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68b430e11850833283288907b655a1fb