### PR TITLE
chore(editor): remove react-hook-form dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1151,15 +1151,6 @@
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
         },
-        "node_modules/@hookform/resolvers": {
-            "version": "3.10.0",
-            "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.10.0.tgz",
-            "integrity": "sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==",
-            "license": "MIT",
-            "peerDependencies": {
-                "react-hook-form": "^7.0.0"
-            }
-        },
         "node_modules/@humanfs/core": {
             "version": "0.19.1",
             "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -4748,22 +4739,6 @@
                 "react": "^18.3.1"
             }
         },
-        "node_modules/react-hook-form": {
-            "version": "7.62.0",
-            "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.62.0.tgz",
-            "integrity": "sha512-7KWFejc98xqG/F4bAxpL41NB3o1nnvQO1RWZT3TqRZYL8RryQETGfEdVnJN2fy1crCiBLLjkRBVK05j24FxJGA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=18.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/react-hook-form"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17 || ^18 || ^19"
-            }
-        },
         "node_modules/react-icons": {
             "version": "5.5.0",
             "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
@@ -5977,12 +5952,10 @@
             "version": "1.0.0",
             "dependencies": {
                 "@angelabc/shared": "1.0.0",
-                "@hookform/resolvers": "^3.9.0",
                 "cors": "^2.8.5",
                 "express": "^5.1.0",
                 "react": "^18.3.1",
                 "react-dom": "^18.3.1",
-                "react-hook-form": "^7.53.0",
                 "react-icons": "^5.5.0"
             }
         },

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -9,8 +9,6 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-icons": "^5.5.0",
-    "react-hook-form": "^7.53.0",
-    "@hookform/resolvers": "^3.9.0",
     "@angelabc/shared": "1.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- remove react-hook-form and @hookform/resolvers from editor package
- update lockfile after dependency removal

## Testing
- `npm run build`
- `npm run build:editor`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68b43af79acc8332a545ad65dc3daa02