### PR TITLE
Fix IoC container resolution ownership

### DIFF
--- a/packages/utils/src/ioc/__tests__/container.test.ts
+++ b/packages/utils/src/ioc/__tests__/container.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+
+import { Container } from '../container'
+import { token } from '../token'
+import type { ILogger } from '../../utils/logger'
+
+class TestLogger implements ILogger {
+    public debug(_category: string, message: string, ..._args: unknown[]): string {
+        return message
+    }
+
+    public info(_category: string, message: string, ..._args: unknown[]): string {
+        return message
+    }
+
+    public warn(_category: string, message: string, ..._args: unknown[]): string {
+        return message
+    }
+
+    public error(_category: string, message: string, ..._args: unknown[]): string {
+        return message
+    }
+}
+
+describe('Container', () => {
+    it('returns the parent singleton when resolved from a child container', () => {
+        const logger = new TestLogger()
+        const root = new Container(logger)
+        const child = root.createChild()
+        const singletonToken = token<{ id: number }>('singleton-service')
+        let factoryCalls = 0
+
+        root.register({
+            token: singletonToken,
+            scope: 'singleton',
+            useFactory: () => ({ id: ++factoryCalls })
+        })
+
+        const fromChildFirst = child.resolve(singletonToken)
+        const fromChildAgain = child.resolve(singletonToken)
+        const fromParent = root.resolve(singletonToken)
+
+        expect(factoryCalls).toBe(1)
+        expect(fromChildFirst).toBe(fromParent)
+        expect(fromChildAgain).toBe(fromParent)
+    })
+
+    it('creates new instances for transient providers registered on a child', () => {
+        const logger = new TestLogger()
+        const root = new Container(logger)
+        const child = root.createChild()
+        const transientToken = token<{ id: number }>('transient-service')
+        let factoryCalls = 0
+
+        child.register({
+            token: transientToken,
+            scope: 'transient',
+            useFactory: () => ({ id: ++factoryCalls })
+        })
+
+        const first = child.resolve(transientToken)
+        const second = child.resolve(transientToken)
+
+        expect(first).not.toBe(second)
+        expect(factoryCalls).toBe(2)
+    })
+})

--- a/packages/utils/src/ioc/container.ts
+++ b/packages/utils/src/ioc/container.ts
@@ -83,12 +83,13 @@ export class Container implements IContainer {
    *   is detected.
    */
   resolve<T>(t: Token<T>): T {
-    if (this.singletons.has(t)) return this.singletons.get(t) as T
-
-    const p = this.providers.get(t) ?? this.parent?.getProvider(t)
-    if (!p) {
+    const provider = this.providers.get(t) as Provider<T> | undefined
+    if (!provider) {
+      if (this.parent) return this.parent.resolve(t)
       throw new Error(this.logger.error(logName, 'No provider for {0}', describeToken(t)))
     }
+
+    if (this.singletons.has(t)) return this.singletons.get(t) as T
 
     if (this.resolving.includes(t)) {
       const path = [...this.resolving, t].map(describeToken).join(' -> ')
@@ -97,18 +98,14 @@ export class Container implements IContainer {
 
     this.resolving.push(t)
     try {
-      const instance = this.instantiate(p)
-      const scope = (p as {scope?: Scope}).scope ?? 'singleton'
-      const isValueFunction = 'useValue' in p && isFunction((p as {useValue: T}).useValue)
+      const instance = this.instantiate(provider)
+      const scope = (provider as {scope?: Scope}).scope ?? 'singleton'
+      const isValueFunction = 'useValue' in provider && isFunction((provider as {useValue: T}).useValue)
       if (scope === 'singleton' && !isValueFunction) this.singletons.set(t, instance)
       return instance as T
     } finally {
       this.resolving.pop()
     }
-  }
-
-  private getProvider<T>(t: Token<T>): Provider<T> | undefined {
-    return (this.providers.get(t) ?? this.parent?.getProvider(t)) as Provider<T> | undefined
   }
 
   /**


### PR DESCRIPTION
## Summary
- update the IoC container so `resolve` delegates to parent containers for ancestor-owned tokens and caches singletons in the owning scope
- add regression tests covering singleton sharing across parent/child containers and transient provider behavior

## Testing
- pnpm lint
- pnpm --filter @angelabc/utils test
- pnpm build *(fails: GAME_DIR env variable is not set)*

------
https://chatgpt.com/codex/tasks/task_e_68d19bb7acec833284e47fcfff89e29d