### PR TITLE
feat(engine): await async initializers

### DIFF
--- a/apps/engine/src/core/__tests__/gameEngine.test.ts
+++ b/apps/engine/src/core/__tests__/gameEngine.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { Mock } from 'vitest'
+import type { ILogger } from '@angelabc/utils/utils'
+import type { IMessageBus } from '@angelabc/utils/utils/messageBus'
+import type { Message } from '@angelabc/utils/utils/types'
+import { GameEngine } from '../gameEngine'
+import { MESSAGE_ENGINE_LOADING, MESSAGE_ENGINE_START } from '../messages'
+import type { IEngineInitializer } from '../initializers/engineInitializer'
+
+const createLogger = (): ILogger => ({
+    debug: vi.fn(() => ''),
+    info: vi.fn(() => ''),
+    warn: vi.fn(() => ''),
+    error: vi.fn(() => '')
+})
+
+const createMessageBus = (): { messageBus: IMessageBus, postMessage: Mock<[Message<unknown>], void> } => {
+    const postMessage = vi.fn<(message: Message<unknown>) => void>() as Mock<[Message<unknown>], void>
+
+    const messageBus: IMessageBus = {
+        postMessage: postMessage as unknown as IMessageBus['postMessage'],
+        registerMessageListener: vi.fn(),
+        registerNotificationMessage: vi.fn(),
+        unregisterNotificationMessage: vi.fn(),
+        disableEmptyQueueAfterPost: vi.fn(),
+        enableEmptyQueueAfterPost: vi.fn(),
+        shutDown: vi.fn()
+    }
+
+    return { messageBus, postMessage }
+}
+
+describe('GameEngine', () => {
+    it('awaits asynchronous engine initializer before broadcasting ENGINE-START', async () => {
+        let resolveInitializer: () => void = () => {}
+        const initializer: IEngineInitializer = {
+            initialize: vi.fn(() => new Promise<void>(resolve => {
+                resolveInitializer = resolve
+            }))
+        }
+
+        const logger = createLogger()
+        const { messageBus, postMessage } = createMessageBus()
+        const engine = new GameEngine(logger, messageBus, initializer)
+
+        const startPromise = engine.start()
+
+        expect(initializer.initialize).toHaveBeenCalledTimes(1)
+        expect(postMessage).not.toHaveBeenCalled()
+
+        resolveInitializer()
+        await startPromise
+
+        expect(postMessage).toHaveBeenNthCalledWith(1, {
+            message: MESSAGE_ENGINE_LOADING,
+            payload: null
+        })
+        expect(postMessage).toHaveBeenNthCalledWith(2, {
+            message: MESSAGE_ENGINE_START,
+            payload: null
+        })
+    })
+
+    it('posts engine events when initializer resolves immediately', async () => {
+        const initializer: IEngineInitializer = {
+            initialize: vi.fn(async () => {})
+        }
+
+        const logger = createLogger()
+        const { messageBus, postMessage } = createMessageBus()
+        const engine = new GameEngine(logger, messageBus, initializer)
+
+        await engine.start()
+
+        expect(initializer.initialize).toHaveBeenCalledTimes(1)
+        expect(postMessage).toHaveBeenNthCalledWith(1, {
+            message: MESSAGE_ENGINE_LOADING,
+            payload: null
+        })
+        expect(postMessage).toHaveBeenNthCalledWith(2, {
+            message: MESSAGE_ENGINE_START,
+            payload: null
+        })
+    })
+})

--- a/apps/engine/src/core/gameEngine.ts
+++ b/apps/engine/src/core/gameEngine.ts
@@ -25,7 +25,7 @@ export class GameEngine implements IGameEngine {
 
     public async start(): Promise<void> {
         this.logger.debug(logName, 'Starting game engine')
-        this.engineInitializer.initialize()
+        await this.engineInitializer.initialize()
         this.messageBus.postMessage({
             message: MESSAGE_ENGINE_LOADING,
             payload: null

--- a/apps/engine/src/core/initializers/engineInitializer.ts
+++ b/apps/engine/src/core/initializers/engineInitializer.ts
@@ -2,7 +2,7 @@ import { Token, token } from '@angelabc/utils/ioc'
 import { IProvidersInitializer, providersInitializerToken } from './providersInitializer'
 
 export interface IEngineInitializer {
-    initialize(): void
+    initialize(): Promise<void>
 }
 
 const logName = 'engineInitializer'
@@ -15,7 +15,7 @@ export class EngineInitializer implements IEngineInitializer {
         private providersInitializer: IProvidersInitializer
     ) { }
 
-    public initialize(): void {
-        this.providersInitializer.initialize()
+    public async initialize(): Promise<void> {
+        await this.providersInitializer.initialize()
     }
 }

--- a/apps/engine/src/core/initializers/providersInitializer.ts
+++ b/apps/engine/src/core/initializers/providersInitializer.ts
@@ -2,7 +2,7 @@ import { Token, token } from '@angelabc/utils/ioc'
 import { gameStateProviderToken, IGameStateProvider } from '../../providers/gameStateProvider'
 
 export interface IProvidersInitializer {
-    initialize(): void
+    initialize(): Promise<void>
 }
 
 const logName = 'ProvidersInitializers'
@@ -15,7 +15,7 @@ export class ProvidersInitializer implements IProvidersInitializer {
         private gameStateProvider: IGameStateProvider
     ) { }
 
-    public initialize(): void {
-        this.gameStateProvider.initialize()
+    public async initialize(): Promise<void> {
+        await this.gameStateProvider.initialize()
     }
 }

--- a/apps/engine/src/providers/gameStateProvider.ts
+++ b/apps/engine/src/providers/gameStateProvider.ts
@@ -6,7 +6,7 @@ import { MESSAGE_ENGINE_LOADING, MESSAGE_ENGINE_START, MESSAGE_ENGINE_STATE_CHAN
 
 export interface IGameStateProvider {
     get GameState(): GameState
-    initialize(): void
+    initialize(): void | Promise<void>
     dispose(): void
 }
 


### PR DESCRIPTION
## Summary
- allow engine and provider initializers to resolve promises
- await engine initialization before broadcasting startup events
- add coverage for asynchronous engine initializers to validate event order

## Testing
- pnpm lint
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d4f3087fac8332b78ff18ea629a057